### PR TITLE
Update readme and improve general consistency

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,6 +1,6 @@
 # Path-to-RegExp
 
-  Turn an Express-style path string such as `/user/:name` into a regular expression.
+Turn an Express-style path string such as `/user/:name` into a regular expression.
 
 [![Build Status](https://img.shields.io/travis/component/path-to-regexp/master.svg)](https://travis-ci.org/component/path-to-regexp)
 [![NPM version](https://img.shields.io/npm/v/path-to-regexp.svg)](https://www.npmjs.org/package/path-to-regexp)
@@ -9,21 +9,85 @@
 
 ```javascript
 var pathToRegexp = require('path-to-regexp');
-```
-### pathToRegexp(path, keys, options)
 
- - **path** A string in the express format, an array of such strings, or a regular expression
- - **keys** An array to be populated with the keys present in the url.  Once the function completes, this will be an array of strings.
- - **options**
-   - **options.sensitive** Defaults to false, set this to true to make routes case sensitive
-   - **options.strict** Defaults to false, set this to true to make the trailing slash matter.
-   - **options.end** Defaults to true, set this to false to only match the prefix of the URL.
+// pathToRegexp(path, keys, options);
+```
+
+- **path** A string in the express format, an array of strings, or a regular expression.
+- **keys** An array to be populated with the keys present in the url.
+- **options**
+  - **options.sensitive** When set to `true` the route will be case sensitive.
+  - **options.strict** When set to `true` a trailing slash will affect the url matching.
+  - **options.end** When set to `false` the url will match only the prefix.
 
 ```javascript
 var keys = [];
-var exp = pathToRegexp('/foo/:bar', keys);
-//keys = ['bar']
-//exp = /^\/foo\/(?:([^\/]+?))\/?$/i
+var re = pathToRegexp('/foo/:bar', keys);
+// re = /^\/foo\/(?:([^\/]+?))\/?$/i
+// keys = [{ name: 'bar', optional: false }]
+```
+
+### Named parameters
+
+Paths have the ability to define named parameters that populate the keys array. Named parameters are defined by prefixing a colon to a parameter name (`:foo`) and optionally suffixing a number of different modifiers. A named parameter will match any text until the next slash.
+
+```javascript
+var re = pathToRegexp('/:foo/:bar');
+
+re.exec('/test/route');
+//=> ['/test/route', 'test', 'route']
+```
+
+#### Optional Matches
+
+Named parameters can be suffixed with a question mark to indicate an optional match.
+
+```javascript
+var re = pathToRegExp('/:foo?');
+
+re.exec('/');
+//=> ['/', undefined]
+```
+
+Please note: Optional matches can be combined with the greedy match to only have it take effect with the parameter exists. E.g. `/:foo*?`.
+
+#### Custom Matching Groups
+
+Named parameters can be provided a custom matching group and override the default. Please note: Backslashes will need to be escaped.
+
+```javascript
+var re = pathToRegexp('/:foo(\\d+)');
+
+re.exec('/123');
+//=> ['/123', '123']
+
+re.exec('/abc');
+//=> null
+```
+
+#### Prefixes
+
+By default a named parameter will match any character up until the next slash, but if the parameter is prefixed with a period it will only match to the next period.
+
+```javascript
+var re = pathToRegexp('/test.:foo');
+
+re.exec('/test.json');
+//=> ['/test.json', 'json']
+
+re.exec('/test.html.json');
+//=> null
+```
+
+### Greedy Matching
+
+The path uses an asterisk to greedily match any trailing characters. This can be placed anywhere in the route, including after a named parameter.
+
+```javascript
+var re = pathToRegexp('/foo*');
+
+re.exec('/foo/bar.json');
+//=> ['/foo/bar', '/bar.json']
 ```
 
 ## Live Demo
@@ -32,4 +96,4 @@ You can see a live demo of this library in use at [express-route-tester](http://
 
 ## License
 
-  MIT
+MIT

--- a/index.js
+++ b/index.js
@@ -5,19 +5,17 @@
 module.exports = pathtoRegexp;
 
 /**
- * Normalize the given path string,
- * returning a regular expression.
+ * Normalize the given path string, returning a regular expression.
  *
- * An empty array should be passed,
- * which will contain the placeholder
- * key names. For example "/user/:id" will
- * then contain ["id"].
+ * An empty array should be passed, which will contain the placeholder key
+ * names. For example "/user/:id" will then contain:
  *
- * @param  {String|RegExp|Array} path
- * @param  {Array} keys
- * @param  {Object} options
+ * [{ name: "id", optional: false }]
+ *
+ * @param  {(String|RegExp|Array)} path
+ * @param  {Array}                 keys
+ * @param  {Object}                options
  * @return {RegExp}
- * @api private
  */
 
 function pathtoRegexp (path, keys, options) {

--- a/test.js
+++ b/test.js
@@ -1,11 +1,11 @@
-var pathToRegExp = require('./');
+var pathToRegexp = require('./');
 var assert = require('assert');
 
 describe('path-to-regexp', function () {
   describe('strings', function () {
     it('should match simple paths', function () {
       var params = [];
-      var m = pathToRegExp('/test', params).exec('/test');
+      var m = pathToRegexp('/test', params).exec('/test');
 
       assert.equal(params.length, 0);
 
@@ -13,9 +13,9 @@ describe('path-to-regexp', function () {
       assert.equal(m[0], '/test');
     });
 
-    it('should match express format params', function () {
+    it('should match named params', function () {
       var params = [];
-      var m = pathToRegExp('/:test', params).exec('/pathname');
+      var m = pathToRegexp('/:test', params).exec('/pathname');
 
       assert.equal(params.length, 1);
       assert.equal(params[0].name, 'test');
@@ -28,7 +28,7 @@ describe('path-to-regexp', function () {
 
     it('should do strict matches', function () {
       var params = [];
-      var re = pathToRegExp('/:test', params, { strict: true });
+      var re = pathToRegexp('/:test', params, { strict: true });
       var m;
 
       assert.equal(params.length, 1);
@@ -48,7 +48,7 @@ describe('path-to-regexp', function () {
 
     it('should do strict matches with trailing slashes', function () {
       var params = [];
-      var re = pathToRegExp('/:test/', params, { strict: true });
+      var re = pathToRegexp('/:test/', params, { strict: true });
       var m;
 
       assert.equal(params.length, 1);
@@ -70,9 +70,9 @@ describe('path-to-regexp', function () {
       assert.ok(!m);
     });
 
-    it('should allow optional express format params', function () {
+    it('should allow optional named params', function () {
       var params = [];
-      var re = pathToRegExp('/:test?', params);
+      var re = pathToRegexp('/:test?', params);
       var m;
 
       assert.equal(params.length, 1);
@@ -92,9 +92,9 @@ describe('path-to-regexp', function () {
       assert.equal(m[1], undefined);
     });
 
-    it('should allow express format param regexps', function () {
+    it('should allow params to have custom matching groups', function () {
       var params = [];
-      var m = pathToRegExp('/:page(\\d+)', params).exec('/56');
+      var m = pathToRegexp('/:page(\\d+)', params).exec('/56');
 
       assert.equal(params.length, 1);
       assert.equal(params[0].name, 'page');
@@ -107,7 +107,7 @@ describe('path-to-regexp', function () {
 
     it('should match without a prefixed slash', function () {
       var params = [];
-      var m = pathToRegExp(':test', params).exec('string');
+      var m = pathToRegexp(':test', params).exec('string');
 
       assert.equal(params.length, 1);
       assert.equal(params[0].name, 'test');
@@ -118,9 +118,9 @@ describe('path-to-regexp', function () {
       assert.equal(m[1], 'string');
     });
 
-    it('should not match format parts', function () {
+    it('should not match the format', function () {
       var params = [];
-      var m = pathToRegExp('/:test.json', params).exec('/route.json');
+      var m = pathToRegexp('/:test.json', params).exec('/route.json');
 
       assert.equal(params.length, 1);
       assert.equal(params[0].name, 'test');
@@ -131,9 +131,9 @@ describe('path-to-regexp', function () {
       assert.equal(m[1], 'route');
     });
 
-    it('should match format parts', function () {
+    it('should match format params', function () {
       var params = [];
-      var re = pathToRegExp('/:test.:format', params);
+      var re = pathToRegexp('/:test.:format', params);
       var m;
 
       assert.equal(params.length, 2);
@@ -154,9 +154,9 @@ describe('path-to-regexp', function () {
       assert.ok(!m);
     });
 
-    it('should match route parts with a trailing format', function () {
+    it('should match a param with a trailing format', function () {
       var params = [];
-      var m = pathToRegExp('/:test.json', params).exec('/route.json');
+      var m = pathToRegexp('/:test.json', params).exec('/route.json');
 
       assert.equal(params.length, 1);
       assert.equal(params[0].name, 'test');
@@ -167,20 +167,29 @@ describe('path-to-regexp', function () {
       assert.equal(m[1], 'route');
     });
 
-    it('should match optional trailing routes', function () {
+    it('should do greedy matches', function () {
       var params = [];
-      var m = pathToRegExp('/test*', params).exec('/test/route');
+      var re = pathToRegexp('/test*', params);
+      var m;
 
       assert.equal(params.length, 0);
+
+      m = re.exec('/test/route');
 
       assert.equal(m.length, 2);
       assert.equal(m[0], '/test/route');
       assert.equal(m[1], '/route');
+
+      m = re.exec('/test');
+
+      assert.equal(m.length, 2);
+      assert.equal(m[0], '/test');
+      assert.equal(m[1], '');
     });
 
-    it('should match optional trailing routes after a param', function () {
+    it('should do greedy param matches', function () {
       var params = [];
-      var re = pathToRegExp('/:test*', params);
+      var re = pathToRegexp('/:test*', params);
       var m;
 
       assert.equal(params.length, 1);
@@ -202,9 +211,9 @@ describe('path-to-regexp', function () {
       assert.equal(m[2], '');
     });
 
-    it('should match optional trailing routes before a format', function () {
+    it('should do greedy matches with a trailing format', function () {
       var params = [];
-      var re = pathToRegExp('/test*.json', params);
+      var re = pathToRegexp('/test*.json', params);
       var m;
 
       assert.equal(params.length, 0);
@@ -228,9 +237,9 @@ describe('path-to-regexp', function () {
       assert.equal(m[1], '/route');
     });
 
-    it('should match optional trailing routes after a param and before a format', function () {
+    it('should do greedy param matches with a trailing format', function () {
       var params = [];
-      var re = pathToRegExp('/:test*.json', params);
+      var re = pathToRegexp('/:test*.json', params);
       var m;
 
       assert.equal(params.length, 1);
@@ -256,9 +265,9 @@ describe('path-to-regexp', function () {
       assert.ok(!m);
     });
 
-    it('should match optional trailing routes between a normal param and a format param', function () {
+    it('should do greedy param matches with a trailing format param', function () {
       var params = [];
-      var re = pathToRegExp('/:test*.:format', params);
+      var re = pathToRegexp('/:test*.:format', params);
       var m;
 
       assert.equal(params.length, 2);
@@ -292,9 +301,9 @@ describe('path-to-regexp', function () {
       assert.ok(!m);
     });
 
-    it('should match optional trailing routes after a param and before an optional format param', function () {
+    it('should do greedy param matches with an optional trailing format param', function () {
       var params = [];
-      var re = pathToRegExp('/:test*.:format?', params);
+      var re = pathToRegexp('/:test*.:format?', params);
       var m;
 
       assert.equal(params.length, 2);
@@ -332,9 +341,9 @@ describe('path-to-regexp', function () {
       assert.ok(!m);
     });
 
-    it('should match optional trailing routes inside optional express param', function () {
+    it('should do greedy, optional param matching', function () {
       var params = [];
-      var re = pathToRegExp('/:test*?', params);
+      var re = pathToRegexp('/:test*?', params);
       var m;
 
       assert.equal(params.length, 1);
@@ -363,14 +372,42 @@ describe('path-to-regexp', function () {
       assert.equal(m[2], undefined);
     });
 
+    it('should do greedy, optional param matching with a custom matching group', function () {
+      var params = [];
+      var re = pathToRegexp('/:test(\\d+)*?', params);
+      var m;
+
+      assert.equal(params.length, 1);
+      assert.equal(params[0].name, 'test');
+      assert.equal(params[0].optional, true);
+
+      m = re.exec('/123');
+
+      assert.equal(m.length, 3);
+      assert.equal(m[0], '/123');
+      assert.equal(m[1], '123');
+      assert.equal(m[2], '');
+
+      m = re.exec('/123/foo/bar');
+
+      assert.equal(m.length, 3);
+      assert.equal(m[0], '/123/foo/bar');
+      assert.equal(m[1], '123');
+      assert.equal(m[2], '/foo/bar');
+
+      m = re.exec('/foo/bar');
+
+      assert.ok(!m);
+    });
+
     it('should do case insensitive matches', function () {
-      var m = pathToRegExp('/test').exec('/TEST');
+      var m = pathToRegexp('/test').exec('/TEST');
 
       assert.equal(m[0], '/TEST');
     });
 
     it('should do case sensitive matches', function () {
-      var re = pathToRegExp('/test', null, { sensitive: true });
+      var re = pathToRegexp('/test', null, { sensitive: true });
       var m;
 
       m = re.exec('/test');
@@ -385,7 +422,7 @@ describe('path-to-regexp', function () {
 
     it('should do non-ending matches', function () {
       var params = [];
-      var m = pathToRegExp('/:test', params, { end: false }).exec('/test/route');
+      var m = pathToRegexp('/:test', params, { end: false }).exec('/test/route');
 
       assert.equal(params.length, 1);
       assert.equal(params[0].name, 'test');
@@ -396,25 +433,31 @@ describe('path-to-regexp', function () {
       assert.equal(m[1], 'test');
     });
 
-    it('should match trailing slashes in non-ending non-strict mode', function () {
+    it('should work with trailing slashes in non-ending mode', function () {
       var params = [];
-      var re = pathToRegExp('/:test', params, { end: false });
+      var re = pathToRegexp('/:test', params, { end: false });
       var m;
 
       assert.equal(params.length, 1);
       assert.equal(params[0].name, 'test');
       assert.equal(params[0].optional, false);
 
-      m = re.exec('/test/');
+      m = re.exec('/foo/bar');
 
       assert.equal(m.length, 2);
-      assert.equal(m[0], '/test/');
-      assert.equal(m[1], 'test');
+      assert.equal(m[0], '/foo');
+      assert.equal(m[1], 'foo');
+
+      m = re.exec('/foo/');
+
+      assert.equal(m.length, 2);
+      assert.equal(m[0], '/foo/');
+      assert.equal(m[1], 'foo');
     });
 
     it('should match trailing slashing in non-ending strict mode', function () {
       var params = [];
-      var re = pathToRegExp('/route/', params, { end: false, strict: true });
+      var re = pathToRegexp('/route/', params, { end: false, strict: true });
 
       assert.equal(params.length, 0);
 
@@ -440,7 +483,7 @@ describe('path-to-regexp', function () {
 
     it('should not match trailing slashes in non-ending strict mode', function () {
       var params = [];
-      var re = pathToRegExp('/route', params, { end: false, strict: true });
+      var re = pathToRegexp('/route', params, { end: false, strict: true });
 
       assert.equal(params.length, 0);
 
@@ -457,7 +500,7 @@ describe('path-to-regexp', function () {
 
     it('should allow matching regexps after a slash', function () {
       var params = [];
-      var re = pathToRegExp('/(\\d+)', params);
+      var re = pathToRegexp('/(\\d+)', params);
       var m;
 
       assert.equal(params.length, 0);
@@ -469,9 +512,9 @@ describe('path-to-regexp', function () {
       assert.equal(m[1], '123');
     });
 
-    it('should match optional formats', function () {
+    it('should match optional format params', function () {
       var params = [];
-      var re = pathToRegExp('/:test.:format?', params);
+      var re = pathToRegexp('/:test.:format?', params);
       var m;
 
       assert.equal(params.length, 2);
@@ -495,9 +538,9 @@ describe('path-to-regexp', function () {
       assert.equal(m[2], 'json');
     });
 
-    it('should match full paths with format by default', function () {
+    it('should match full paths when not prefixed with a period', function () {
       var params = [];
-      var m = pathToRegExp('/:test', params).exec('/test.json');
+      var m = pathToRegexp('/:test', params).exec('/test.json');
 
       assert.equal(params.length, 1);
       assert.equal(params[0].name, 'test');
@@ -511,13 +554,13 @@ describe('path-to-regexp', function () {
 
   describe('regexps', function () {
     it('should return the regexp', function () {
-      assert.deepEqual(pathToRegExp(/.*/), /.*/);
+      assert.deepEqual(pathToRegexp(/.*/), /.*/);
     });
   });
 
   describe('arrays', function () {
     it('should join arrays parts', function () {
-      var re = pathToRegExp(['/test', '/route']);
+      var re = pathToRegexp(['/test', '/route']);
 
       assert.ok(re.test('/test'));
       assert.ok(re.test('/route'));
@@ -526,7 +569,7 @@ describe('path-to-regexp', function () {
 
     it('should match parts properly', function () {
       var params = [];
-      var re = pathToRegExp(['/:test', '/test/:route'], params);
+      var re = pathToRegexp(['/:test', '/test/:route'], params);
       var m;
 
       assert.equal(params.length, 2);


### PR DESCRIPTION
Now pushing empty matching groups into the keys array and asterisk matches will come out as `undefined` instead of empty strings when nothing matches (making it consistent with the optional matches). Updated readme to reflect all available options, but please review the text and make sure I'm not being overly verbose or missing information. 
