### PR TITLE
Compatibility updates

### DIFF
--- a/test.js
+++ b/test.js
@@ -46,6 +46,30 @@ describe('path-to-regexp', function () {
       assert.ok(!m);
     });
 
+    it('should do strict matches with trailing slashes', function () {
+      var params = [];
+      var re = pathToRegExp('/:test/', params, { strict: true });
+      var m;
+
+      assert.equal(params.length, 1);
+      assert.equal(params[0].name, 'test');
+      assert.equal(params[0].optional, false);
+
+      m = re.exec('/route');
+
+      assert.ok(!m);
+
+      m = re.exec('/route/');
+
+      assert.equal(m.length, 2);
+      assert.equal(m[0], '/route/');
+      assert.equal(m[1], 'route');
+
+      m = re.exec('/route//');
+
+      assert.ok(!m);
+    });
+
     it('should allow optional express format params', function () {
       var params = [];
       var re = pathToRegExp('/:test?', params);
@@ -388,19 +412,47 @@ describe('path-to-regexp', function () {
       assert.equal(m[1], 'test');
     });
 
+    it('should match trailing slashing in non-ending strict mode', function () {
+      var params = [];
+      var re = pathToRegExp('/route/', params, { end: false, strict: true });
+
+      assert.equal(params.length, 0);
+
+      m = re.exec('/route/');
+
+      assert.equal(m.length, 1);
+      assert.equal(m[0], '/route/');
+
+      m = re.exec('/route/test');
+
+      assert.equal(m.length, 1);
+      assert.equal(m[0], '/route/');
+
+      m = re.exec('/route');
+
+      assert.ok(!m);
+
+      m = re.exec('/route//');
+
+      assert.equal(m.length, 1);
+      assert.equal(m[0], '/route/');
+    });
+
     it('should not match trailing slashes in non-ending strict mode', function () {
       var params = [];
-      var re = pathToRegExp('/:test', params, { end: false, strict: true });
+      var re = pathToRegExp('/route', params, { end: false, strict: true });
 
-      assert.equal(params.length, 1);
-      assert.equal(params[0].name, 'test');
-      assert.equal(params[0].optional, false);
+      assert.equal(params.length, 0);
 
-      m = re.exec('/test/');
+      m = re.exec('/route');
 
-      assert.equal(m.length, 2);
-      assert.equal(m[0], '/test');
-      assert.equal(m[1], 'test');
+      assert.equal(m.length, 1);
+      assert.equal(m[0], '/route');
+
+      m = re.exec('/route/');
+
+      assert.ok(m.length, 1);
+      assert.equal(m[0], '/route');
     });
 
     it('should allow matching regexps after a slash', function () {
@@ -467,9 +519,35 @@ describe('path-to-regexp', function () {
     it('should join arrays parts', function () {
       var re = pathToRegExp(['/test', '/route']);
 
-      assert.ok(re.exec('/test'));
-      assert.ok(re.exec('/route'));
-      assert.ok(!re.exec('/else'));
+      assert.ok(re.test('/test'));
+      assert.ok(re.test('/route'));
+      assert.ok(!re.test('/else'));
+    });
+
+    it('should match parts properly', function () {
+      var params = [];
+      var re = pathToRegExp(['/:test', '/test/:route'], params);
+      var m;
+
+      assert.equal(params.length, 2);
+      assert.equal(params[0].name, 'test');
+      assert.equal(params[0].optional, false);
+      assert.equal(params[1].name, 'route');
+      assert.equal(params[1].optional, false);
+
+      m = re.exec('/route');
+
+      assert.equal(m.length, 3);
+      assert.equal(m[0], '/route');
+      assert.equal(m[1], 'route');
+      assert.equal(m[2], undefined);
+
+      m = re.exec('/test/path');
+
+      assert.equal(m.length, 3);
+      assert.equal(m[0], '/test/path');
+      assert.equal(m[1], undefined);
+      assert.equal(m[2], 'path');
     });
   });
 });


### PR DESCRIPTION
- Better support for non-ending strict mode matches with a trailing slash
- Proper support for passing in arrays

On a side note, I added `|` to the escape keys - this may break backward compatibility if someone is awkwardly relying on it in their string or in a matching group. I might take a stab at only replacing these characters outside of matching groups and pushing custom matching groups into the keys array - any thoughts on this?
