### PR TITLE
Escape special characters outside matching groups

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,6 +5,46 @@
 module.exports = pathtoRegexp;
 
 /**
+ * Validate a group capture and push the relevant keys. It assumes the incoming
+ * capturing group is wrapped in parentheses with any modifiers at the end.
+ *
+ * @param  {String} capture
+ * @param  {Array}  keys
+ * @return {String}
+ */
+function validateGroup (capture, keys, pushed) {
+  // Filter out escaped parentheses. E.g. `\\(`.
+  var groups = capture.match(/(?:^|[^\\])(?:\\\\)*\([^?]/g);
+
+  // Push empty keys into the key array for each capturing group.
+  if (groups) {
+    keys.push.apply(keys, new Array(groups.length - (pushed ? 1 : 0)));
+  }
+
+  return capture.replace(/\//g, '\\/');
+};
+
+/**
+ * Core path to regexp utility.
+ *
+ * @type {RegExp}
+ */
+var PATH_REGEXP = new RegExp([
+  // Match escaped regexp characters that would otherwise be used incorrectly
+  // in other matches. This allows the user to escape characters that shouldn't
+  // be transformed.
+  '(\\\\.)',
+  // Match Express-style params with a prefix and optional suffixes.
+  '([\\/\\.])?:(\\w+)(\\(.*?\\))?(\\*)?(\\?)?',
+  // Match user-defined regexp matching groups.
+  '(\\(.*?\\)[*+?]?)',
+  // Match regexp special characters that need to be escaped.
+  '([.+?=^!:${}|[\\]\\/])',
+  // Finally, enable automatic greedy matching with an asterisk.
+  '(\\*)'
+].join('|'), 'g');
+
+/**
  * Normalize the given path string,
  * returning a regular expression.
  *
@@ -19,7 +59,6 @@ module.exports = pathtoRegexp;
  * @return {RegExp}
  * @api private
  */
-
 function pathtoRegexp(path, keys, options) {
   options = options || {};
   var sensitive = options.sensitive;
@@ -31,15 +70,29 @@ function pathtoRegexp(path, keys, options) {
   if (path instanceof Array) path = '(' + path.join('|') + ')';
 
   path = path
-    .concat(strict ? '' : '/?')
-    .replace(/([\/\.])/g, '\\$1')
-    .replace(/(\\\/)?(\\\.)?:(\w+)(\(.*?\))?(\*)?(\?)?/g, function (match, slash, format, key, capture, star, optional) {
-      slash = slash || '';
-      format = format || '';
-      capture = capture || '([^/' + format + ']+?)';
-      optional = optional || '';
+    .replace(PATH_REGEXP, function (match, escaped, prefix, key, capture, star, optional, group, escape, anything) {
+      if (escaped) {
+        return escaped;
+      }
+
+      if (escape) {
+        return '\\' + escape;
+      }
+
+      if (group) {
+        return validateGroup(group, keys);
+      }
+
+      if (anything) {
+        return validateGroup('(.*)', keys);
+      }
 
       keys.push({ name: key, optional: !!optional });
+
+      slash = prefix === '/' ? '\\/' : '';
+      format = prefix === '.' ? '\\.' : '';
+      capture = validateGroup(capture || '([^\\/' + format + ']+?)', keys, true);
+      optional = optional || '';
 
       return ''
         + (optional ? '' : slash)
@@ -49,7 +102,7 @@ function pathtoRegexp(path, keys, options) {
         + ')'
         + optional;
     })
-    .replace(/\*/g, '(.*)');
+    .concat(strict ? '' : '\\/?');
 
-  return new RegExp('^' + path + (end ? '$' : '(?=\/|$)'), sensitive ? '' : 'i');
+  return new RegExp('^' + path + (end ? '$' : '(?=\\/|$)'), sensitive ? '' : 'i');
 };


### PR DESCRIPTION
Changes:
- Introduces logic for escaping regexp special characters outside of matching groups
- Correctly identify regexp matching groups and push `undefined` values into the keys array so keys can be correctly matched
- Allow escaping of path special characters (asterisk, parentheses, etc.)
- Improved testing readability using `deepEqual`, will update all tests when all PRs are merged
