### PR TITLE
Couple fixes for 0.1.x series

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,7 +42,7 @@ function pathtoRegexp(path, keys, options) {
     return new RegExp('(?:' + path.join('|') + ')', flags);
   }
 
-  path = ('^' + path + (strict ? '' : '/?'))
+  path = ('^' + path + (strict ? '' : path[path.length - 1] === '/' ? '?' : '/?'))
     .replace(/\/\(/g, '/(?:')
     .replace(/([\/\.])/g, '\\$1')
     .replace(/(\\\/)?(\\\.)?:(\w+)(\(.*?\))?(\*)?(\?)?/g, function (match, slash, format, key, capture, star, optional) {

--- a/test.js
+++ b/test.js
@@ -412,6 +412,34 @@ describe('path-to-regexp', function () {
       assert.equal(m[1], 'test');
     });
 
+    it('should match trailing slashes in non-ending non-strict mode', function () {
+      var params = [];
+      var re = pathToRegExp('/route/', params, { end: false });
+      var m;
+
+      assert.equal(params.length, 0);
+
+      m = re.exec('/route/');
+
+      assert.equal(m.length, 1);
+      assert.equal(m[0], '/route/');
+
+      m = re.exec('/route/test');
+
+      assert.equal(m.length, 1);
+      assert.equal(m[0], '/route');
+
+      m = re.exec('/route');
+
+      assert.equal(m.length, 1);
+      assert.equal(m[0], '/route');
+
+      m = re.exec('/route//');
+
+      assert.equal(m.length, 1);
+      assert.equal(m[0], '/route/');
+    });
+
     it('should match trailing slashing in non-ending strict mode', function () {
       var params = [];
       var re = pathToRegExp('/route/', params, { end: false, strict: true });


### PR DESCRIPTION
Hi @blakeembrey these are the changes that, if released as like a 0.1.x series, would be awesome to have for express 4.x series (specifically, for https://github.com/visionmedia/express/issues/2207).

The two commits in here by you are just e3df26313d4ee1ddb3fec9389ad0f1c43598b980 split in half (I thought I only needed one half, but apparently did need both parts of that commit).

I also made an additional commit that is also needed to use it with `app.use`.

You had also brought up an issue with `mergeParams` option in https://github.com/visionmedia/express/issues/2207#issuecomment-48078903 so if they relate to this, let me know :) These changes I have tested against express 4.x with a patch to support express issue 2207 and they all pass.

As for the numeric index issue, the numberic indicies I was supporting was from the line https://github.com/visionmedia/express/blob/master/lib/router/layer.js#L53 , which is always in order without holes.
