### PR TITLE
index: Add shims for ES5 methods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 coverage
+components

--- a/component.json
+++ b/component.json
@@ -11,5 +11,8 @@
   "scripts": [
     "index.js"
   ],
-  "license": "MIT"
+  "license": "MIT",
+  "dependencies": {
+    "juliangruber/isarray": "0.0.1"
+  }
 }

--- a/index.js
+++ b/index.js
@@ -1,3 +1,5 @@
+var isArray = require('isarray');
+
 /**
  * Expose `pathtoRegexp`.
  */
@@ -58,7 +60,7 @@ function attachKeys (re, keys) {
  * @return {RegExp}
  */
 function pathtoRegexp (path, keys, options) {
-  if (!Array.isArray(keys)) {
+  if (!isArray(keys)) {
     options = keys;
     keys = null;
   }
@@ -94,7 +96,7 @@ function pathtoRegexp (path, keys, options) {
   // Map array parts into regexps and return their source. We also pass
   // the same keys and options instance into every generation to get
   // consistent matching groups before we join the sources together.
-  if (Array.isArray(path)) {
+  if (isArray(path)) {
     var parts = [];
 
     for (var i = 0; i < path.length; i++) {

--- a/package.json
+++ b/package.json
@@ -24,5 +24,8 @@
   "devDependencies": {
     "istanbul": "~0.3.0",
     "mocha": "~1.21.4"
+  },
+  "dependencies": {
+    "isarray": "0.0.1"
   }
 }


### PR DESCRIPTION
Legacy JS engines don't support `Array.isArray` or `Array#map`.  This
patch implements simple shims to compensate for horribly old browsers
(IE8).
