### PR TITLE
Deprecate usage of white-space character in path

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 var isArray = require('isarray');
+var deprecate = require('depd')('path-to-regexp');
 
 /**
  * Expose `pathToRegexp`.
@@ -175,6 +176,10 @@ function pathToRegexp (path, keys, options) {
 
   if (isArray(path)) {
     return arrayToRegexp(path, keys, options);
+  }
+
+  if (path.indexOf(' ') !== -1) {
+    deprecate('White-space characters are not supported by URL paths, you must encode them as %20.');
   }
 
   var strict = options.strict;

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "mocha": "~1.21.4"
   },
   "dependencies": {
+    "depd": "~1.0.0",
     "isarray": "0.0.1"
   }
 }


### PR DESCRIPTION
Referring to https://github.com/strongloop/express/issues/2511, added fix to deprecate usage of white-space character in path. 

Can one of the maintainers please review this?
