### PR TITLE
Expose path parser

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,6 +1,6 @@
 # Path-to-RegExp
 
-Turn an Express-style path string such as `/user/:name` into a regular expression.
+> Turn an Express-style path string such as `/user/:name` into a regular expression.
 
 [![NPM version][npm-image]][npm-url]
 [![Build status][travis-image]][travis-url]
@@ -21,6 +21,8 @@ npm install path-to-regexp --save
 var pathToRegexp = require('path-to-regexp')
 
 // pathToRegexp(path, keys, options)
+// pathToRegexp.parse(path)
+// pathToRegexp.compile(path)
 ```
 
 - **path** A string in the express format, an array of strings, or a regular expression.
@@ -127,11 +129,45 @@ re.exec('/test/route')
 //=> ['/test/route', 'test', 'route']
 ```
 
+### Parse
+
+The parse function is exposed via `pathToRegexp.parse`. This will yield an array of strings and keys.
+
+```js
+var tokens = pathToRegexp.parse('/route/:foo/(.*)')
+
+console.log(tokens[0])
+//=> "/route"
+
+console.log(tokens[1])
+//=> { name: 'foo', prefix: '/', delimiter: '/', optional: false, repeat: false, pattern: '[^\\/]+?' }
+
+console.log(tokens[2])
+//=> { name: 0, prefix: '/', delimiter: '/', optional: false, repeat: false, pattern: '.*' }
+```
+
+**Note:** This method only works with strings.
+
+### Compile ("Reverse" Path-To-RegExp)
+
+Path-To-RegExp exposes a compile function for transforming an express path into valid path. Confusing enough? This example will straighten everything out for you.
+
+```js
+var toPath = pathToRegexp.compile('/user/:id')
+
+var result = toPath({ id: 123 })
+
+console.log(result)
+//=> "/user/123"
+```
+
+**Note:** The generated function will throw on any invalid input. It will execute all necessary checks to ensure the generated path is valid. This method only works with strings.
+
 ## Compatibility with Express <= 4.x
 
 Path-To-RegExp breaks compatibility with Express <= 4.x in a few ways:
 
-* RegExp special characters can now be used in the regular path. E.g. `/user[(\\d+)]`
+* RegExp special characters can now be used in the regular path. E.g. `/user/(\\d+)`
 * All RegExp special characters can now be used inside the custom match. E.g. `/:user(.*)`
 * No more support for asterisk matching - use an explicit parameter instead. E.g. `/(.*)`
 * Parameters can have suffixes that augment meaning - `*`, `+` and `?`. E.g. `/:user*`

--- a/Readme.md
+++ b/Readme.md
@@ -34,7 +34,7 @@ var pathToRegexp = require('path-to-regexp')
 var keys = []
 var re = pathToRegexp('/foo/:bar', keys)
 // re = /^\/foo\/([^\/]+?)\/?$/i
-// keys = [{ name: 'bar', delimiter: '/', optional: false, repeat: false, offset: 5, length: 4 }]
+// keys = [{ name: 'bar', prefix: '/', delimiter: '/', optional: false, repeat: false, pattern: '[^\\/]+?' }]
 ```
 
 ### Parameters

--- a/index.js
+++ b/index.js
@@ -221,9 +221,11 @@ function regexpToRegexp (path, keys) {
     for (var i = 0; i < groups.length; i++) {
       keys.push({
         name: i,
+        prefix: null,
         delimiter: null,
         optional: false,
-        repeat: false
+        repeat: false,
+        pattern: null
       })
     }
   }

--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ var isarray = require('isarray')
  * Expose `pathToRegexp`.
  */
 module.exports = pathToRegexp
+module.exports.parse = parse
 
 /**
  * The main path matching regexp utility.
@@ -19,10 +20,83 @@ var PATH_REGEXP = new RegExp([
   //
   // "/:test(\\d+)?" => ["/", "test", "\d+", undefined, "?"]
   // "/route(\\d+)" => [undefined, undefined, undefined, "\d+", undefined]
-  '([\\/.])?((?:\\:(\\w+)(?:\\(((?:\\\\.|[^)])*)\\))?|\\(((?:\\\\.|[^)])*)\\))([+*?])?)',
-  // Match regexp special characters that are always escaped.
-  '([.+*?=^!:${}()[\\]|\\/])'
+  '([\\/.])?(?:\\:(\\w+)(?:\\(((?:\\\\.|[^)])*)\\))?|\\(((?:\\\\.|[^)])*)\\))([+*?])?'
 ].join('|'), 'g')
+
+/**
+ * Parse a string for the raw tokens.
+ *
+ * @param  {String} str
+ * @return {Array}
+ */
+function parse (str) {
+  var tokens = []
+  var key = 0
+  var index = 0
+  var path = ''
+  var res
+
+  while ((res = PATH_REGEXP.exec(str)) != null) {
+    var m = res[0]
+    var escaped = res[1]
+    var offset = res.index
+    path += str.slice(index, offset)
+    index = offset + m.length
+
+    // Ignore already escaped sequences.
+    if (escaped) {
+      path += escaped[1]
+      continue
+    }
+
+    // Push the current path onto the tokens.
+    if (path) {
+      tokens.push(path)
+      path = ''
+    }
+
+    var prefix = res[2]
+    var name = res[3]
+    var capture = res[4]
+    var group = res[5]
+    var suffix = res[6]
+
+    var repeat = suffix === '+' || suffix === '*'
+    var optional = suffix === '?' || suffix === '*'
+    var delimiter = prefix || '/'
+
+    tokens.push({
+      name: name || key++,
+      prefix: prefix || '',
+      delimiter: delimiter,
+      optional: optional,
+      repeat: repeat,
+      pattern: escapeGroup(capture || group || '[^' + delimiter + ']+?')
+    })
+  }
+
+  // Match any characters still remaining.
+  if (index < str.length) {
+    path += str.substr(index)
+  }
+
+  // If the path exists, push it onto the end.
+  if (path) {
+    tokens.push(path)
+  }
+
+  return tokens
+}
+
+/**
+ * Escape a regular expression string.
+ *
+ * @param  {String} str
+ * @return {String}
+ */
+function escapeString (str) {
+  return str.replace(/([.+*?=^!:${}()[\]|\/])/g, '\\$1')
+}
 
 /**
  * Escape the capturing group by escaping special characters and meaning.
@@ -101,52 +175,68 @@ function arrayToRegexp (path, keys, options) {
 }
 
 /**
- * Replace the specific tags with regexp strings.
+ * Create a path regexp from string input.
  *
  * @param  {String} path
  * @param  {Array}  keys
- * @return {String}
+ * @param  {Object} options
+ * @return {RegExp}
  */
-function replacePath (path, keys) {
-  var index = 0
+function stringToRegexp (path, keys, options) {
+  var strict = options.strict
+  var end = options.end !== false
+  var route = ''
+  var endsWithSlash = path.charAt(path.length - 1) === '/'
+  var tokens = parse(path)
 
-  function replace (_, escaped, prefix, all, key, capture, group, suffix, escape, i) {
-    if (escaped) {
-      return escaped
+  // Iterate over the tokens and create our regexp string.
+  for (var i = 0; i < tokens.length; i++) {
+    var token = tokens[i]
+
+    if (typeof token === 'string') {
+      route += escapeString(token)
+    } else {
+      var prefix = escapeString(token.prefix)
+      var capture = token.pattern
+
+      // Push non-string tokens into the keys array.
+      keys.push(token)
+
+      if (token.repeat) {
+        capture += '(?:' + prefix + capture + ')*'
+      }
+
+      if (token.optional) {
+        if (prefix) {
+          capture = '(?:' + prefix + '(' + capture + '))?'
+        } else {
+          capture = '(' + capture + ')?'
+        }
+      } else {
+        capture = prefix + '(' + capture + ')'
+      }
+
+      route += capture
     }
-
-    if (escape) {
-      return '\\' + escape
-    }
-
-    var repeat = suffix === '+' || suffix === '*'
-    var optional = suffix === '?' || suffix === '*'
-
-    keys.push({
-      name: key || index++,
-      delimiter: prefix || '/',
-      optional: optional,
-      repeat: repeat,
-      offset: i + (prefix ? prefix.length : 0),
-      length: all.length
-    })
-
-    prefix = prefix ? ('\\' + prefix) : ''
-    capture = escapeGroup(capture || group || '[^' + (prefix || '\\/') + ']+?')
-
-    if (repeat) {
-      capture = capture + '(?:' + prefix + capture + ')*'
-    }
-
-    if (optional) {
-      return '(?:' + prefix + '(' + capture + '))?'
-    }
-
-    // Basic parameter support.
-    return prefix + '(' + capture + ')'
   }
 
-  return path.replace(PATH_REGEXP, replace)
+  // In non-strict mode we allow a slash at the end of match. If the path to
+  // match already ends with a slash, we remove it for consistency. The slash
+  // is valid at the end of a path match, not in the middle. This is important
+  // in non-ending mode, where "/test/" shouldn't match "/test//route".
+  if (!strict) {
+    route = (endsWithSlash ? route.slice(0, -2) : route) + '(?:\\/(?=$))?'
+  }
+
+  if (end) {
+    route += '$'
+  } else {
+    // In non-ending mode, we need the capturing groups to match as much as
+    // possible by using a positive lookahead to the end or next path segment.
+    route += strict && endsWithSlash ? '' : '(?=\\/|$)'
+  }
+
+  return attachKeys(new RegExp('^' + route, flags(options)), keys)
 }
 
 /**
@@ -179,26 +269,5 @@ function pathToRegexp (path, keys, options) {
     return arrayToRegexp(path, keys, options)
   }
 
-  var strict = options.strict
-  var end = options.end !== false
-  var route = replacePath(path, keys)
-  var endsWithSlash = path.charAt(path.length - 1) === '/'
-
-  // In non-strict mode we allow a slash at the end of match. If the path to
-  // match already ends with a slash, we remove it for consistency. The slash
-  // is valid at the end of a path match, not in the middle. This is important
-  // in non-ending mode, where "/test/" shouldn't match "/test//route".
-  if (!strict) {
-    route = (endsWithSlash ? route.slice(0, -2) : route) + '(?:\\/(?=$))?'
-  }
-
-  if (end) {
-    route += '$'
-  } else {
-    // In non-ending mode, we need the capturing groups to match as much as
-    // possible by using a positive lookahead to the end or next path segment.
-    route += strict && endsWithSlash ? '' : '(?=\\/|$)'
-  }
-
-  return attachKeys(new RegExp('^' + route, flags(options)), keys)
+  return stringToRegexp(path, keys, options)
 }

--- a/index.js
+++ b/index.js
@@ -143,7 +143,7 @@ function compile (str) {
         }
 
         for (var j = 0; j < value.length; j++) {
-          if (!key.regexp.test(value)) {
+          if (!key.regexp.test(value[j])) {
             throw new TypeError('Expected all "' + key.name + '" to match "' + key.pattern + '"')
           }
 

--- a/package.json
+++ b/package.json
@@ -7,8 +7,9 @@
     "LICENSE"
   ],
   "scripts": {
-    "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- -R spec",
     "lint": "standard",
+    "test-spec": "mocha -R spec --bail",
+    "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- -R spec",
     "test": "npm run lint && npm run test-cov"
   },
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "url": "https://github.com/pillarjs/path-to-regexp.git"
   },
   "devDependencies": {
+    "chai": "^2.3.0",
     "istanbul": "~0.3.0",
     "mocha": "~2.2.4",
     "pre-commit": "~1.0.5"

--- a/package.json
+++ b/package.json
@@ -29,11 +29,11 @@
   },
   "devDependencies": {
     "istanbul": "~0.3.0",
-    "mocha": "~2.1.0",
+    "mocha": "~2.2.4",
     "pre-commit": "~1.0.5"
   },
   "dependencies": {
     "isarray": "0.0.1",
-    "standard": "~2.10.0"
+    "standard": "~3.7.3"
   }
 }

--- a/test.js
+++ b/test.js
@@ -52,14 +52,14 @@ var TESTS = [
   ['/test/', [], '/test//route', ['/test'], { end: false }],
   [
     '/:test',
-    [{ name: 'test', delimiter: '/', optional: false, repeat: false }],
+    [{ name: 'test', prefix: '/', delimiter: '/', optional: false, repeat: false, pattern: '[^\\/]+?' }],
     '/route',
     ['/route', 'route'],
     { end: false }
   ],
   [
     '/:test/',
-    [{ name: 'test', delimiter: '/', optional: false, repeat: false }],
+    [{ name: 'test', prefix: '/', delimiter: '/', optional: false, repeat: false, pattern: '[^\\/]+?' }],
     '/route',
     ['/route', 'route'],
     { end: false }
@@ -79,28 +79,28 @@ var TESTS = [
   ['/test.json', [], '/test.json.hbs', null, { end: false, strict: true }],
   [
     '/:test',
-    [{ name: 'test', delimiter: '/', optional: false, repeat: false }],
+    [{ name: 'test', prefix: '/', delimiter: '/', optional: false, repeat: false, pattern: '[^\\/]+?' }],
     '/route',
     ['/route', 'route'],
     { end: false, strict: true }
   ],
   [
     '/:test',
-    [{ name: 'test', delimiter: '/', optional: false, repeat: false }],
+    [{ name: 'test', prefix: '/', delimiter: '/', optional: false, repeat: false, pattern: '[^\\/]+?' }],
     '/route/',
     ['/route', 'route'],
     { end: false, strict: true }
   ],
   [
     '/:test/',
-    [{ name: 'test', delimiter: '/', optional: false, repeat: false }],
+    [{ name: 'test', prefix: '/', delimiter: '/', optional: false, repeat: false, pattern: '[^\\/]+?' }],
     '/route/',
     ['/route/', 'route'],
     { end: false, strict: true }
   ],
   [
     '/:test/',
-    [{ name: 'test', delimiter: '/', optional: false, repeat: false }],
+    [{ name: 'test', prefix: '/', delimiter: '/', optional: false, repeat: false, pattern: '[^\\/]+?' }],
     '/route',
     null,
     { end: false, strict: true }
@@ -124,58 +124,58 @@ var TESTS = [
    */
   [
     '/:test',
-    [{ name: 'test', delimiter: '/', optional: false, repeat: false }],
+    [{ name: 'test', prefix: '/', delimiter: '/', optional: false, repeat: false, pattern: '[^\\/]+?' }],
     '/route',
     ['/route', 'route']
   ],
   [
     '/:test',
-    [{ name: 'test', delimiter: '/', optional: false, repeat: false }],
+    [{ name: 'test', prefix: '/', delimiter: '/', optional: false, repeat: false, pattern: '[^\\/]+?' }],
     '/another',
     ['/another', 'another']
   ],
   [
     '/:test',
-    [{ name: 'test', delimiter: '/', optional: false, repeat: false }],
+    [{ name: 'test', prefix: '/', delimiter: '/', optional: false, repeat: false, pattern: '[^\\/]+?' }],
     '/something/else',
     null
   ],
   [
     '/:test',
-    [{ name: 'test', delimiter: '/', optional: false, repeat: false }],
+    [{ name: 'test', prefix: '/', delimiter: '/', optional: false, repeat: false, pattern: '[^\\/]+?' }],
     '/route.json',
     ['/route.json', 'route.json']
   ],
   [
     '/:test',
-    [{ name: 'test', delimiter: '/', optional: false, repeat: false }],
+    [{ name: 'test', prefix: '/', delimiter: '/', optional: false, repeat: false, pattern: '[^\\/]+?' }],
     '/route',
     ['/route', 'route'],
     { strict: true }],
   [
     '/:test',
-    [{ name: 'test', delimiter: '/', optional: false, repeat: false }],
+    [{ name: 'test', prefix: '/', delimiter: '/', optional: false, repeat: false, pattern: '[^\\/]+?' }],
     '/route/',
     null,
     { strict: true }
   ],
   [
     '/:test/',
-    [{ name: 'test', delimiter: '/', optional: false, repeat: false }],
+    [{ name: 'test', prefix: '/', delimiter: '/', optional: false, repeat: false, pattern: '[^\\/]+?' }],
     '/route/',
     ['/route/', 'route'],
     { strict: true }
   ],
   [
     '/:test/',
-    [{ name: 'test', delimiter: '/', optional: false, repeat: false }],
+    [{ name: 'test', prefix: '/', delimiter: '/', optional: false, repeat: false, pattern: '[^\\/]+?' }],
     '/route//',
     null,
     { strict: true }
   ],
   [
     '/:test',
-    [{ name: 'test', delimiter: '/', optional: false, repeat: false }],
+    [{ name: 'test', prefix: '/', delimiter: '/', optional: false, repeat: false, pattern: '[^\\/]+?' }],
     '/route.json',
     ['/route.json', 'route.json'],
     { end: false }
@@ -186,52 +186,52 @@ var TESTS = [
    */
   [
     '/:test?',
-    [{ name: 'test', delimiter: '/', optional: true, repeat: false }],
+    [{ name: 'test', prefix: '/', delimiter: '/', optional: true, repeat: false, pattern: '[^\\/]+?' }],
     '/route',
     ['/route', 'route']
   ],
   [
     '/:test?',
-    [{ name: 'test', delimiter: '/', optional: true, repeat: false }],
+    [{ name: 'test', prefix: '/', delimiter: '/', optional: true, repeat: false, pattern: '[^\\/]+?' }],
     '/route/nested',
     null
   ],
   [
     '/:test?',
-    [{ name: 'test', delimiter: '/', optional: true, repeat: false }],
+    [{ name: 'test', prefix: '/', delimiter: '/', optional: true, repeat: false, pattern: '[^\\/]+?' }],
     '/',
     ['/', undefined]
   ],
   [
     '/:test?',
-    [{ name: 'test', delimiter: '/', optional: true, repeat: false }],
+    [{ name: 'test', prefix: '/', delimiter: '/', optional: true, repeat: false, pattern: '[^\\/]+?' }],
     '/route',
     ['/route', 'route'],
     { strict: true }
   ],
   [
     '/:test?',
-    [{ name: 'test', delimiter: '/', optional: true, repeat: false }],
+    [{ name: 'test', prefix: '/', delimiter: '/', optional: true, repeat: false, pattern: '[^\\/]+?' }],
     '/',
     null, // Questionable behaviour.
     { strict: true }
   ],
   [
     '/:test?/',
-    [{ name: 'test', delimiter: '/', optional: true, repeat: false }],
+    [{ name: 'test', prefix: '/', delimiter: '/', optional: true, repeat: false, pattern: '[^\\/]+?' }],
     '/',
     ['/', undefined],
     { strict: true }
   ],
   [
     '/:test?/',
-    [{ name: 'test', delimiter: '/', optional: true, repeat: false }],
+    [{ name: 'test', prefix: '/', delimiter: '/', optional: true, repeat: false, pattern: '[^\\/]+?' }],
     '//',
     null
   ],
   [
     '/:test?/',
-    [{ name: 'test', delimiter: '/', optional: true, repeat: false }],
+    [{ name: 'test', prefix: '/', delimiter: '/', optional: true, repeat: false, pattern: '[^\\/]+?' }],
     '//',
     null,
     { strict: true }
@@ -240,49 +240,49 @@ var TESTS = [
   // Repeated once or more times parameters.
   [
     '/:test+',
-    [{ name: 'test', delimiter: '/', optional: false, repeat: true }],
+    [{ name: 'test', prefix: '/', delimiter: '/', optional: false, repeat: true, pattern: '[^\\/]+?' }],
     '/',
     null
   ],
   [
     '/:test+',
-    [{ name: 'test', delimiter: '/', optional: false, repeat: true }],
+    [{ name: 'test', prefix: '/', delimiter: '/', optional: false, repeat: true, pattern: '[^\\/]+?' }],
     '/route',
     ['/route', 'route']
   ],
   [
     '/:test+',
-    [{ name: 'test', delimiter: '/', optional: false, repeat: true }],
+    [{ name: 'test', prefix: '/', delimiter: '/', optional: false, repeat: true, pattern: '[^\\/]+?' }],
     '/some/basic/route',
     ['/some/basic/route', 'some/basic/route']
   ],
   [
     '/:test(\\d+)+',
-    [{ name: 'test', delimiter: '/', optional: false, repeat: true }],
+    [{ name: 'test', prefix: '/', delimiter: '/', optional: false, repeat: true, pattern: '\\d+' }],
     '/abc/456/789',
     null
   ],
   [
     '/:test(\\d+)+',
-    [{ name: 'test', delimiter: '/', optional: false, repeat: true }],
+    [{ name: 'test', prefix: '/', delimiter: '/', optional: false, repeat: true, pattern: '\\d+' }],
     '/123/456/789',
     ['/123/456/789', '123/456/789']
   ],
   [
     '/route.:ext(json|xml)+',
-    [{ name: 'ext', delimiter: '.', optional: false, repeat: true }],
+    [{ name: 'ext', prefix: '.', delimiter: '.', optional: false, repeat: true, pattern: 'json|xml' }],
     '/route.json',
     ['/route.json', 'json']
   ],
   [
     '/route.:ext(json|xml)+',
-    [{ name: 'ext', delimiter: '.', optional: false, repeat: true }],
+    [{ name: 'ext', prefix: '.', delimiter: '.', optional: false, repeat: true, pattern: 'json|xml' }],
     '/route.xml.json',
     ['/route.xml.json', 'xml.json']
   ],
   [
     '/route.:ext(json|xml)+',
-    [{ name: 'ext', delimiter: '.', optional: false, repeat: true }],
+    [{ name: 'ext', prefix: '.', delimiter: '.', optional: false, repeat: true, pattern: 'json|xml' }],
     '/route.html',
     null
   ],
@@ -292,49 +292,49 @@ var TESTS = [
    */
   [
     '/:test*',
-    [{ name: 'test', delimiter: '/', optional: true, repeat: true }],
+    [{ name: 'test', prefix: '/', delimiter: '/', optional: true, repeat: true, pattern: '[^\\/]+?' }],
     '/',
     ['/', undefined]
   ],
   [
     '/:test*',
-    [{ name: 'test', delimiter: '/', optional: true, repeat: true }],
+    [{ name: 'test', prefix: '/', delimiter: '/', optional: true, repeat: true, pattern: '[^\\/]+?' }],
     '//',
     null
   ],
   [
     '/:test*',
-    [{ name: 'test', delimiter: '/', optional: true, repeat: true }],
+    [{ name: 'test', prefix: '/', delimiter: '/', optional: true, repeat: true, pattern: '[^\\/]+?' }],
     '/route',
     ['/route', 'route']
   ],
   [
     '/:test*',
-    [{ name: 'test', delimiter: '/', optional: true, repeat: true }],
+    [{ name: 'test', prefix: '/', delimiter: '/', optional: true, repeat: true, pattern: '[^\\/]+?' }],
     '/some/basic/route',
     ['/some/basic/route', 'some/basic/route']
   ],
   [
     '/route.:ext([a-z]+)*',
-    [{ name: 'ext', delimiter: '.', optional: true, repeat: true }],
+    [{ name: 'ext', prefix: '.', delimiter: '.', optional: true, repeat: true, pattern: '[a-z]+' }],
     '/route',
     ['/route', undefined]
   ],
   [
     '/route.:ext([a-z]+)*',
-    [{ name: 'ext', delimiter: '.', optional: true, repeat: true }],
+    [{ name: 'ext', prefix: '.', delimiter: '.', optional: true, repeat: true, pattern: '[a-z]+' }],
     '/route.json',
     ['/route.json', 'json']
   ],
   [
     '/route.:ext([a-z]+)*',
-    [{ name: 'ext', delimiter: '.', optional: true, repeat: true }],
+    [{ name: 'ext', prefix: '.', delimiter: '.', optional: true, repeat: true, pattern: '[a-z]+' }],
     '/route.xml.json',
     ['/route.xml.json', 'xml.json']
   ],
   [
     '/route.:ext([a-z]+)*',
-    [{ name: 'ext', delimiter: '.', optional: true, repeat: true }],
+    [{ name: 'ext', prefix: '.', delimiter: '.', optional: true, repeat: true, pattern: '[a-z]+' }],
     '/route.123',
     null
   ],
@@ -342,56 +342,56 @@ var TESTS = [
   // Custom named parameters.
   [
     '/:test(\\d+)',
-    [{ name: 'test', delimiter: '/', optional: false, repeat: false }],
+    [{ name: 'test', prefix: '/', delimiter: '/', optional: false, repeat: false, pattern: '\\d+' }],
     '/123',
     ['/123', '123']
   ],
   [
     '/:test(\\d+)',
-    [{ name: 'test', delimiter: '/', optional: false, repeat: false }],
+    [{ name: 'test', prefix: '/', delimiter: '/', optional: false, repeat: false, pattern: '\\d+' }],
     '/abc',
     null
   ],
   [
     '/:test(\\d+)',
-    [{ name: 'test', delimiter: '/', optional: false, repeat: false }],
+    [{ name: 'test', prefix: '/', delimiter: '/', optional: false, repeat: false, pattern: '\\d+' }],
     '/123/abc',
     null
   ],
   [
     '/:test(\\d+)',
-    [{ name: 'test', delimiter: '/', optional: false, repeat: false }],
+    [{ name: 'test', prefix: '/', delimiter: '/', optional: false, repeat: false, pattern: '\\d+' }],
     '/123/abc',
     ['/123', '123'],
     { end: false }
   ],
   [
     '/:test(.*)',
-    [{ name: 'test', delimiter: '/', optional: false, repeat: false }],
+    [{ name: 'test', prefix: '/', delimiter: '/', optional: false, repeat: false, pattern: '.*' }],
     '/anything/goes/here',
     ['/anything/goes/here', 'anything/goes/here']
   ],
   [
     '/:route([a-z]+)',
-    [{ name: 'route', delimiter: '/', optional: false, repeat: false }],
+    [{ name: 'route', prefix: '/', delimiter: '/', optional: false, repeat: false, pattern: '[a-z]+' }],
     '/abcde',
     ['/abcde', 'abcde']
   ],
   [
     '/:route([a-z]+)',
-    [{ name: 'route', delimiter: '/', optional: false, repeat: false }],
+    [{ name: 'route', prefix: '/', delimiter: '/', optional: false, repeat: false, pattern: '[a-z]+' }],
     '/12345',
     null
   ],
   [
     '/:route(this|that)',
-    [{ name: 'route', delimiter: '/', optional: false, repeat: false }],
+    [{ name: 'route', prefix: '/', delimiter: '/', optional: false, repeat: false, pattern: 'this|that' }],
     '/this',
     ['/this', 'this']
   ],
   [
     '/:route(this|that)',
-    [{ name: 'route', delimiter: '/', optional: false, repeat: false }],
+    [{ name: 'route', prefix: '/', delimiter: '/', optional: false, repeat: false, pattern: 'this|that' }],
     '/that',
     ['/that', 'that']
   ],
@@ -407,39 +407,39 @@ var TESTS = [
   ],
   [
     ':test',
-    [{ name: 'test', delimiter: '/', optional: false, repeat: false }],
+    [{ name: 'test', prefix: '', delimiter: '/', optional: false, repeat: false, pattern: '[^\\/]+?' }],
     'route',
     ['route', 'route']
   ],
   [
     ':test',
-    [{ name: 'test', delimiter: '/', optional: false, repeat: false }],
+    [{ name: 'test', prefix: '', delimiter: '/', optional: false, repeat: false, pattern: '[^\\/]+?' }],
     '/route',
     null
   ],
   [
     ':test',
-    [{ name: 'test', delimiter: '/', optional: false, repeat: false }],
+    [{ name: 'test', prefix: '', delimiter: '/', optional: false, repeat: false, pattern: '[^\\/]+?' }],
     'route/',
     ['route/', 'route']
   ],
   [
     ':test',
-    [{ name: 'test', delimiter: '/', optional: false, repeat: false }],
+    [{ name: 'test', prefix: '', delimiter: '/', optional: false, repeat: false, pattern: '[^\\/]+?' }],
     'route/',
     null,
     { strict: true }
   ],
   [
     ':test',
-    [{ name: 'test', delimiter: '/', optional: false, repeat: false }],
+    [{ name: 'test', prefix: '', delimiter: '/', optional: false, repeat: false, pattern: '[^\\/]+?' }],
     'route/',
     ['route/', 'route'],
     { end: false }
   ],
   [
     ':test?',
-    [{ name: 'test', delimiter: '/', optional: true, repeat: false }],
+    [{ name: 'test', prefix: '', delimiter: '/', optional: true, repeat: false, pattern: '[^\\/]+?' }],
     '',
     ['', undefined]
   ],
@@ -461,26 +461,26 @@ var TESTS = [
   ],
   [
     '/:test.json',
-    [{ name: 'test', delimiter: '/', optional: false, repeat: false }],
+    [{ name: 'test', prefix: '/', delimiter: '/', optional: false, repeat: false, pattern: '[^\\/]+?' }],
     '/route.json',
     ['/route.json', 'route']
   ],
   [
     '/:test.json',
-    [{ name: 'test', delimiter: '/', optional: false, repeat: false }],
+    [{ name: 'test', prefix: '/', delimiter: '/', optional: false, repeat: false, pattern: '[^\\/]+?' }],
     '/route.json.json',
     ['/route.json.json', 'route.json']
   ],
   [
     '/:test.json',
-    [{ name: 'test', delimiter: '/', optional: false, repeat: false }],
+    [{ name: 'test', prefix: '/', delimiter: '/', optional: false, repeat: false, pattern: '[^\\/]+?' }],
     '/route.json',
     ['/route.json', 'route'],
     { end: false }
   ],
   [
     '/:test.json',
-    [{ name: 'test', delimiter: '/', optional: false, repeat: false }],
+    [{ name: 'test', prefix: '/', delimiter: '/', optional: false, repeat: false, pattern: '[^\\/]+?' }],
     '/route.json.json',
     ['/route.json.json', 'route.json'],
     { end: false }
@@ -491,21 +491,21 @@ var TESTS = [
    */
   [
     '/test.:format',
-    [{ name: 'format', delimiter: '.', optional: false, repeat: false }],
+    [{ name: 'format', prefix: '.', delimiter: '.', optional: false, repeat: false, pattern: '[^.]+?' }],
     '/test.html',
     ['/test.html', 'html']
   ],
   [
     '/test.:format',
-    [{ name: 'format', delimiter: '.', optional: false, repeat: false }],
+    [{ name: 'format', prefix: '.', delimiter: '.', optional: false, repeat: false, pattern: '[^.]+?' }],
     '/test.hbs.html',
     null
   ],
   [
     '/test.:format.:format',
     [
-      { name: 'format', delimiter: '.', optional: false, repeat: false },
-      { name: 'format', delimiter: '.', optional: false, repeat: false }
+      { name: 'format', prefix: '.', delimiter: '.', optional: false, repeat: false, pattern: '[^.]+?' },
+      { name: 'format', prefix: '.', delimiter: '.', optional: false, repeat: false, pattern: '[^.]+?' }
     ],
     '/test.hbs.html',
     ['/test.hbs.html', 'hbs', 'html']
@@ -513,21 +513,21 @@ var TESTS = [
   [
     '/test.:format+',
     [
-      { name: 'format', delimiter: '.', optional: false, repeat: true }
+      { name: 'format', prefix: '.', delimiter: '.', optional: false, repeat: true, pattern: '[^.]+?' }
     ],
     '/test.hbs.html',
     ['/test.hbs.html', 'hbs.html']
   ],
   [
     '/test.:format',
-    [{ name: 'format', delimiter: '.', optional: false, repeat: false }],
+    [{ name: 'format', prefix: '.', delimiter: '.', optional: false, repeat: false, pattern: '[^.]+?' }],
     '/test.hbs.html',
     null,
     { end: false }
   ],
   [
     '/test.:format.',
-    [{ name: 'format', delimiter: '.', optional: false, repeat: false }],
+    [{ name: 'format', prefix: '.', delimiter: '.', optional: false, repeat: false, pattern: '[^.]+?' }],
     '/test.hbs.html',
     null,
     { end: false }
@@ -539,8 +539,8 @@ var TESTS = [
   [
     '/:test.:format',
     [
-      { name: 'test', delimiter: '/', optional: false, repeat: false },
-      { name: 'format', delimiter: '.', optional: false, repeat: false }
+      { name: 'test', prefix: '/', delimiter: '/', optional: false, repeat: false, pattern: '[^\\/]+?' },
+      { name: 'format', prefix: '.', delimiter: '.', optional: false, repeat: false, pattern: '[^.]+?' }
     ],
     '/route.html',
     ['/route.html', 'route', 'html']
@@ -548,8 +548,8 @@ var TESTS = [
   [
     '/:test.:format',
     [
-      { name: 'test', delimiter: '/', optional: false, repeat: false },
-      { name: 'format', delimiter: '.', optional: false, repeat: false }
+      { name: 'test', prefix: '/', delimiter: '/', optional: false, repeat: false, pattern: '[^\\/]+?' },
+      { name: 'format', prefix: '.', delimiter: '.', optional: false, repeat: false, pattern: '[^.]+?' }
     ],
     '/route',
     null
@@ -557,8 +557,8 @@ var TESTS = [
   [
     '/:test.:format',
     [
-      { name: 'test', delimiter: '/', optional: false, repeat: false },
-      { name: 'format', delimiter: '.', optional: false, repeat: false }
+      { name: 'test', prefix: '/', delimiter: '/', optional: false, repeat: false, pattern: '[^\\/]+?' },
+      { name: 'format', prefix: '.', delimiter: '.', optional: false, repeat: false, pattern: '[^.]+?' }
     ],
     '/route',
     null
@@ -566,8 +566,8 @@ var TESTS = [
   [
     '/:test.:format?',
     [
-      { name: 'test', delimiter: '/', optional: false, repeat: false },
-      { name: 'format', delimiter: '.', optional: true, repeat: false }
+      { name: 'test', prefix: '/', delimiter: '/', optional: false, repeat: false, pattern: '[^\\/]+?' },
+      { name: 'format', prefix: '.', delimiter: '.', optional: true, repeat: false, pattern: '[^.]+?' }
     ],
     '/route',
     ['/route', 'route', undefined]
@@ -575,8 +575,8 @@ var TESTS = [
   [
     '/:test.:format?',
     [
-      { name: 'test', delimiter: '/', optional: false, repeat: false },
-      { name: 'format', delimiter: '.', optional: true, repeat: false }
+      { name: 'test', prefix: '/', delimiter: '/', optional: false, repeat: false, pattern: '[^\\/]+?' },
+      { name: 'format', prefix: '.', delimiter: '.', optional: true, repeat: false, pattern: '[^.]+?' }
     ],
     '/route.json',
     ['/route.json', 'route', 'json']
@@ -584,8 +584,8 @@ var TESTS = [
   [
     '/:test.:format?',
     [
-      { name: 'test', delimiter: '/', optional: false, repeat: false },
-      { name: 'format', delimiter: '.', optional: true, repeat: false }
+      { name: 'test', prefix: '/', delimiter: '/', optional: false, repeat: false, pattern: '[^\\/]+?' },
+      { name: 'format', prefix: '.', delimiter: '.', optional: true, repeat: false, pattern: '[^.]+?' }
     ],
     '/route',
     ['/route', 'route', undefined],
@@ -594,8 +594,8 @@ var TESTS = [
   [
     '/:test.:format?',
     [
-      { name: 'test', delimiter: '/', optional: false, repeat: false },
-      { name: 'format', delimiter: '.', optional: true, repeat: false }
+      { name: 'test', prefix: '/', delimiter: '/', optional: false, repeat: false, pattern: '[^\\/]+?' },
+      { name: 'format', prefix: '.', delimiter: '.', optional: true, repeat: false, pattern: '[^.]+?' }
     ],
     '/route.json',
     ['/route.json', 'route', 'json'],
@@ -604,8 +604,8 @@ var TESTS = [
   [
     '/:test.:format?',
     [
-      { name: 'test', delimiter: '/', optional: false, repeat: false },
-      { name: 'format', delimiter: '.', optional: true, repeat: false }
+      { name: 'test', prefix: '/', delimiter: '/', optional: false, repeat: false, pattern: '[^\\/]+?' },
+      { name: 'format', prefix: '.', delimiter: '.', optional: true, repeat: false, pattern: '[^.]+?' }
     ],
     '/route.json.html',
     ['/route.json.html', 'route.json', 'html'],
@@ -613,14 +613,14 @@ var TESTS = [
   ],
   [
     '/test.:format(.*)z',
-    [{ name: 'format', delimiter: '.', optional: false, repeat: false }],
+    [{ name: 'format', prefix: '.', delimiter: '.', optional: false, repeat: false, pattern: '.*' }],
     '/test.abc',
     null,
     { end: false }
   ],
   [
     '/test.:format(.*)z',
-    [{ name: 'format', delimiter: '.', optional: false, repeat: false }],
+    [{ name: 'format', prefix: '.', delimiter: '.', optional: false, repeat: false, pattern: '.*' }],
     '/test.abcz',
     ['/test.abcz', 'abc'],
     { end: false }
@@ -631,57 +631,57 @@ var TESTS = [
    */
   [
     '/(\\d+)',
-    [{ name: 0, delimiter: '/', optional: false, repeat: false }],
+    [{ name: 0, prefix: '/', delimiter: '/', optional: false, repeat: false, pattern: '\\d+' }],
     '/123',
     ['/123', '123']
   ],
   [
     '/(\\d+)',
-    [{ name: 0, delimiter: '/', optional: false, repeat: false }],
+    [{ name: 0, prefix: '/', delimiter: '/', optional: false, repeat: false, pattern: '\\d+' }],
     '/abc',
     null
   ],
   [
     '/(\\d+)',
-    [{ name: 0, delimiter: '/', optional: false, repeat: false }],
+    [{ name: 0, prefix: '/', delimiter: '/', optional: false, repeat: false, pattern: '\\d+' }],
     '/123/abc',
     null
   ],
   [
     '/(\\d+)',
-    [{ name: 0, delimiter: '/', optional: false, repeat: false }],
+    [{ name: 0, prefix: '/', delimiter: '/', optional: false, repeat: false, pattern: '\\d+' }],
     '/123/abc',
     ['/123', '123'],
     { end: false }
   ],
   [
     '/(\\d+)',
-    [{ name: 0, delimiter: '/', optional: false, repeat: false }],
+    [{ name: 0, prefix: '/', delimiter: '/', optional: false, repeat: false, pattern: '\\d+' }],
     '/abc',
     null,
     { end: false }
   ],
   [
     '/(\\d+)?',
-    [{ name: 0, delimiter: '/', optional: true, repeat: false }],
+    [{ name: 0, prefix: '/', delimiter: '/', optional: true, repeat: false, pattern: '\\d+' }],
     '/',
     ['/', undefined]
   ],
   [
     '/(\\d+)?',
-    [{ name: 0, delimiter: '/', optional: true, repeat: false }],
+    [{ name: 0, prefix: '/', delimiter: '/', optional: true, repeat: false, pattern: '\\d+' }],
     '/123',
     ['/123', '123']
   ],
   [
     '/(.*)',
-    [{ name: 0, delimiter: '/', optional: false, repeat: false }],
+    [{ name: 0, prefix: '/', delimiter: '/', optional: false, repeat: false, pattern: '.*' }],
     '/route',
     ['/route', 'route']
   ],
   [
     '/(.*)',
-    [{ name: 0, delimiter: '/', optional: false, repeat: false }],
+    [{ name: 0, prefix: '/', delimiter: '/', optional: false, repeat: false, pattern: '.*' }],
     '/route/nested',
     ['/route/nested', 'route/nested']
   ],
@@ -697,13 +697,13 @@ var TESTS = [
   ],
   [
     /(.*)/,
-    [{ name: 0, delimiter: null, optional: false, repeat: false }],
+    [{ name: 0, prefix: null, delimiter: null, optional: false, repeat: false, pattern: null }],
     '/match/anything',
     ['/match/anything', '/match/anything']
   ],
   [
     /\/(\d+)/,
-    [{ name: 0, delimiter: null, optional: false, repeat: false }],
+    [{ name: 0, prefix: null, delimiter: null, optional: false, repeat: false, pattern: null }],
     '/123',
     ['/123', '123']
   ],
@@ -713,15 +713,15 @@ var TESTS = [
    */
   [
     ['/test', /\/(\d+)/],
-    [{ name: 0, delimiter: null, optional: false, repeat: false }],
+    [{ name: 0, prefix: null, delimiter: null, optional: false, repeat: false, pattern: null }],
     '/test',
     ['/test', undefined]
   ],
   [
     ['/:test(\\d+)', /(.*)/],
     [
-      { name: 'test', delimiter: '/', optional: false, repeat: false },
-      { name: 0, delimiter: null, optional: false, repeat: false }
+      { name: 'test', prefix: '/', delimiter: '/', optional: false, repeat: false, pattern: '\\d+' },
+      { name: 0, prefix: null, delimiter: null, optional: false, repeat: false, pattern: null }
     ],
     '/123',
     ['/123', '123', undefined]
@@ -729,8 +729,8 @@ var TESTS = [
   [
     ['/:test(\\d+)', /(.*)/],
     [
-      { name: 'test', delimiter: '/', optional: false, repeat: false },
-      { name: 0, delimiter: null, optional: false, repeat: false }
+      { name: 'test', prefix: '/', delimiter: '/', optional: false, repeat: false, pattern: '\\d+' },
+      { name: 0, prefix: null, delimiter: null, optional: false, repeat: false, pattern: null }
     ],
     '/abc',
     ['/abc', undefined, '/abc']
@@ -742,8 +742,8 @@ var TESTS = [
   [
     ['/:test', '/route/:test'],
     [
-      { name: 'test', delimiter: '/', optional: false, repeat: false },
-      { name: 'test', delimiter: '/', optional: false, repeat: false }
+      { name: 'test', prefix: '/', delimiter: '/', optional: false, repeat: false, pattern: '[^\\/]+?' },
+      { name: 'test', prefix: '/', delimiter: '/', optional: false, repeat: false, pattern: '[^\\/]+?' }
     ],
     '/test',
     ['/test', 'test', undefined]
@@ -751,8 +751,8 @@ var TESTS = [
   [
     ['/:test', '/route/:test'],
     [
-      { name: 'test', delimiter: '/', optional: false, repeat: false },
-      { name: 'test', delimiter: '/', optional: false, repeat: false }
+      { name: 'test', prefix: '/', delimiter: '/', optional: false, repeat: false, pattern: '[^\\/]+?' },
+      { name: 'test', prefix: '/', delimiter: '/', optional: false, repeat: false, pattern: '[^\\/]+?' }
     ],
     '/route/test',
     ['/route/test', undefined, 'test']
@@ -760,8 +760,8 @@ var TESTS = [
   [
     [/^\/([^\/]+)$/, /^\/route\/([^\/]+)$/],
     [
-      { name: 0, delimiter: null, optional: false, repeat: false },
-      { name: 0, delimiter: null, optional: false, repeat: false }
+      { name: 0, prefix: null, delimiter: null, optional: false, repeat: false, pattern: null },
+      { name: 0, prefix: null, delimiter: null, optional: false, repeat: false, pattern: null }
     ],
     '/test',
     ['/test', 'test', undefined]
@@ -769,8 +769,8 @@ var TESTS = [
   [
     [/^\/([^\/]+)$/, /^\/route\/([^\/]+)$/],
     [
-      { name: 0, delimiter: null, optional: false, repeat: false },
-      { name: 0, delimiter: null, optional: false, repeat: false }
+      { name: 0, prefix: null, delimiter: null, optional: false, repeat: false, pattern: null },
+      { name: 0, prefix: null, delimiter: null, optional: false, repeat: false, pattern: null }
     ],
     '/route/test',
     ['/route/test', undefined, 'test']
@@ -814,8 +814,8 @@ var TESTS = [
   [
     '/:foo/:bar',
     [
-      { name: 'foo', delimiter: '/', optional: false, repeat: false },
-      { name: 'bar', delimiter: '/', optional: false, repeat: false }
+      { name: 'foo', prefix: '/', delimiter: '/', optional: false, repeat: false, pattern: '[^\\/]+?' },
+      { name: 'bar', prefix: '/', delimiter: '/', optional: false, repeat: false, pattern: '[^\\/]+?' }
     ],
     '/match/route',
     ['/match/route', 'match', 'route']
@@ -823,8 +823,8 @@ var TESTS = [
   [
     '/:remote([\\w-.]+)/:user([\\w-]+)',
     [
-      { name: 'remote', delimiter: '/', optional: false, repeat: false },
-      { name: 'user', delimiter: '/', optional: false, repeat: false }
+      { name: 'remote', prefix: '/', delimiter: '/', optional: false, repeat: false, pattern: '[\\w-.]+' },
+      { name: 'user', prefix: '/', delimiter: '/', optional: false, repeat: false, pattern: '[\\w-]+' }
     ],
     '/endpoint/user',
     ['/endpoint/user', 'endpoint', 'user']
@@ -832,7 +832,7 @@ var TESTS = [
   [
     '/:foo\\?',
     [
-      { name: 'foo', delimiter: '/', optional: false, repeat: false }
+      { name: 'foo', prefix: '/', delimiter: '/', optional: false, repeat: false, pattern: '[^\\/]+?' }
     ],
     '/route?',
     ['/route?', 'route']
@@ -992,14 +992,9 @@ describe('path-to-regexp', function () {
         var keys = []
         var re = pathToRegexp(test[0], keys, test[4])
 
-        // Remove pattern from the keys to test (subjective).
-        var params = keys.map(function (value) {
-          return omit(['prefix', 'pattern'], value)
-        })
-
         // Check the keys match each other and the expected output.
         expect(re.keys).to.equal(keys)
-        expect(params).to.deep.equal(test[1])
+        expect(keys).to.deep.equal(test[1])
 
         // Run the regexp and check the result as expected.
         expect(exec(re, test[2])).to.deep.equal(test[3])
@@ -1019,23 +1014,4 @@ function exec (re, str) {
   var match = re.exec(str)
 
   return match && Array.prototype.slice.call(match)
-}
-
-/**
- * Omit keys from the source object.
- *
- * @param  {Array}  keys
- * @param  {Object} src
- * @return {Object}
- */
-function omit (keys, src) {
-  var dest = {}
-
-  Object.keys(src).forEach(function (key) {
-    if (keys.indexOf(key) === -1) {
-      dest[key] = src[key]
-    }
-  })
-
-  return dest
 }

--- a/test.js
+++ b/test.js
@@ -5,10 +5,7 @@ var expect = require('chai').expect
 var pathToRegexp = require('./')
 
 /**
- * An array of test cases with expected inputs and outputs. The format of each
- * array item is:
- *
- * ["path", "expected params", "route", "expected output", "options"]
+ * An array of test cases with expected inputs and outputs.
  *
  * @type {Array}
  */
@@ -16,169 +13,452 @@ var TESTS = [
   /**
    * Simple paths.
    */
-  ['/', [], '/', ['/']],
-  ['/test', [], '/test', ['/test']],
-  ['/test', [], '/route', null],
-  ['/test', [], '/test/route', null],
-  ['/test', [], '/test/', ['/test/']],
-  ['/test/', [], '/test', ['/test']],
-  ['/test/', [], '/test/', ['/test/']],
-  ['/test/', [], '/test//', null],
+  [
+    '/',
+    null,
+    [
+      '/'
+    ],
+    [
+      ['/', ['/']],
+      ['/route', null]
+    ],
+    [
+      [null, '/'],
+      [{}, '/'],
+      [{ id: 123 }, '/']
+    ]
+  ],
+  [
+    '/test',
+    null,
+    [
+      '/test'
+    ],
+    [
+      ['/test', ['/test']],
+      ['/route', null],
+      ['/test/route', null],
+      ['/test/', ['/test/']]
+    ],
+    [
+      [null, '/test'],
+      [{}, '/test']
+    ]
+  ],
+  [
+    '/test/',
+    null,
+    [
+      '/test/'
+    ],
+    [
+      ['/test', ['/test']],
+      ['/test/', ['/test/']],
+      ['/test//', null]
+    ],
+    [
+      [null, '/test/']
+    ]
+  ],
 
   /**
    * Case-sensitive paths.
    */
-  ['/test', [], '/test', ['/test'], { sensitive: true }],
-  ['/test', [], '/TEST', null, { sensitive: true }],
-  ['/TEST', [], '/test', null, { sensitive: true }],
+  [
+    '/test',
+    {
+      sensitive: true
+    },
+    [
+      '/test'
+    ],
+    [
+      ['/test', ['/test']],
+      ['/TEST', null]
+    ],
+    [
+      [null, '/test']
+    ]
+  ],
+  [
+    '/TEST',
+    {
+      sensitive: true
+    },
+    [
+      '/TEST'
+    ],
+    [
+      ['/test', null],
+      ['/TEST', ['/TEST']]
+    ],
+    [
+      [null, '/TEST']
+    ]
+  ],
 
   /**
    * Strict mode.
    */
-  ['/test', [], '/test', ['/test'], { strict: true }],
-  ['/test', [], '/test/', null, { strict: true }],
-  ['/test/', [], '/test', null, { strict: true }],
-  ['/test/', [], '/test/', ['/test/'], { strict: true }],
-  ['/test/', [], '/test//', null, { strict: true }],
+  [
+    '/test',
+    {
+      strict: true
+    },
+    [
+      '/test'
+    ],
+    [
+      ['/test', ['/test']],
+      ['/test/', null],
+      ['/TEST', ['/TEST']]
+    ],
+    [
+      [null, '/test']
+    ]
+  ],
+  [
+    '/test/',
+    {
+      strict: true
+    },
+    [
+      '/test/'
+    ],
+    [
+      ['/test', null],
+      ['/test/', ['/test/']],
+      ['/test//', null]
+    ],
+    [
+      [null, '/test/']
+    ]
+  ],
 
   /**
    * Non-ending mode.
    */
-  ['/test', [], '/test', ['/test'], { end: false }],
-  ['/test', [], '/test/', ['/test/'], { end: false }],
-  ['/test', [], '/test/route', ['/test'], { end: false }],
-  ['/test/', [], '/test/route', ['/test'], { end: false }],
-  ['/test/', [], '/test//', ['/test'], { end: false }],
-  ['/test/', [], '/test//route', ['/test'], { end: false }],
+  [
+    '/test',
+    {
+      end: false
+    },
+    [
+      '/test'
+    ],
+    [
+      ['/test', ['/test']],
+      ['/test/', ['/test/']],
+      ['/test/route', ['/test']],
+      ['/route', null]
+    ],
+    [
+      [null, '/test']
+    ]
+  ],
+  [
+    '/test/',
+    {
+      end: false
+    },
+    [
+      '/test/'
+    ],
+    [
+      ['/test/route', ['/test']],
+      ['/test//', ['/test']],
+      ['/test//route', ['/test']]
+    ],
+    [
+      [null, '/test/']
+    ]
+  ],
   [
     '/:test',
-    [{ name: 'test', prefix: '/', delimiter: '/', optional: false, repeat: false, pattern: '[^\\/]+?' }],
-    '/route',
-    ['/route', 'route'],
-    { end: false }
+    {
+      end: false
+    },
+    [
+      {
+        name: 'test',
+        prefix: '/',
+        delimiter: '/',
+        optional: false,
+        repeat: false,
+        pattern: '[^\\/]+?'
+      }
+    ],
+    [
+      ['/route', ['/route', 'route']]
+    ],
+    [
+      [{}, null],
+      [{ test: 'abc' }, '/abc']
+    ]
   ],
   [
     '/:test/',
-    [{ name: 'test', prefix: '/', delimiter: '/', optional: false, repeat: false, pattern: '[^\\/]+?' }],
-    '/route',
-    ['/route', 'route'],
-    { end: false }
+    {
+      end: false
+    },
+    [
+      {
+        name: 'test',
+        prefix: '/',
+        delimiter: '/',
+        optional: false,
+        repeat: false,
+        pattern: '[^\\/]+?'
+      },
+      '/'
+    ],
+    [
+      ['/route', ['/route', 'route']]
+    ],
+    [
+      [{ test: 'abc' }, '/abc/']
+    ]
   ],
 
   /**
    * Combine modes.
    */
-  ['/test', [], '/test', ['/test'], { end: false, strict: true }],
-  ['/test', [], '/test/', ['/test'], { end: false, strict: true }],
-  ['/test', [], '/test/route', ['/test'], { end: false, strict: true }],
-  ['/test/', [], '/test', null, { end: false, strict: true }],
-  ['/test/', [], '/test/', ['/test/'], { end: false, strict: true }],
-  ['/test/', [], '/test//', ['/test/'], { end: false, strict: true }],
-  ['/test/', [], '/test/route', ['/test/'], { end: false, strict: true }],
-  ['/test.json', [], '/test.json', ['/test.json'], { end: false, strict: true }],
-  ['/test.json', [], '/test.json.hbs', null, { end: false, strict: true }],
   [
-    '/:test',
-    [{ name: 'test', prefix: '/', delimiter: '/', optional: false, repeat: false, pattern: '[^\\/]+?' }],
-    '/route',
-    ['/route', 'route'],
-    { end: false, strict: true }
+    '/test',
+    {
+      end: false,
+      strict: true
+    },
+    [
+      '/test'
+    ],
+    [
+      ['/test', ['/test']],
+      ['/test/', ['/test']],
+      ['/test/route', ['/test']]
+    ],
+    [
+      [null, '/test']
+    ]
+  ],
+  [
+    '/test/',
+    {
+      end: false,
+      strict: true
+    },
+    [
+      '/test/'
+    ],
+    [
+      ['/test', null],
+      ['/test/', ['/test/']],
+      ['/test//', ['/test/']],
+      ['/test/route', ['/test/']]
+    ],
+    [
+      [null, '/test/']
+    ]
+  ],
+  [
+    '/test.json',
+    {
+      end: false,
+      strict: true
+    },
+    [
+      '/test.json'
+    ],
+    [
+      ['/test.json', ['/test.json']],
+      ['/test.json.hbs', null],
+      ['/test.json/route', ['/test.json']]
+    ],
+    [
+      [null, '/test.json']
+    ]
   ],
   [
     '/:test',
-    [{ name: 'test', prefix: '/', delimiter: '/', optional: false, repeat: false, pattern: '[^\\/]+?' }],
-    '/route/',
-    ['/route', 'route'],
-    { end: false, strict: true }
+    {
+      end: false,
+      strict: true
+    },
+    [
+      {
+        name: 'test',
+        prefix: '/',
+        delimiter: '/',
+        optional: false,
+        repeat: false,
+        pattern: '[^\\/]+?'
+      }
+    ],
+    [
+      ['/route', ['/route', 'route']],
+      ['/route/', ['/route', 'route']]
+    ],
+    [
+      [{}, null],
+      [{ test: 'abc' }, '/abc']
+    ]
   ],
   [
     '/:test/',
-    [{ name: 'test', prefix: '/', delimiter: '/', optional: false, repeat: false, pattern: '[^\\/]+?' }],
-    '/route/',
-    ['/route/', 'route'],
-    { end: false, strict: true }
-  ],
-  [
-    '/:test/',
-    [{ name: 'test', prefix: '/', delimiter: '/', optional: false, repeat: false, pattern: '[^\\/]+?' }],
-    '/route',
-    null,
-    { end: false, strict: true }
+    {
+      end: false,
+      strict: true
+    },
+    [
+      {
+        name: 'test',
+        prefix: '/',
+        delimiter: '/',
+        optional: false,
+        repeat: false,
+        pattern: '[^\\/]+?'
+      },
+      '/'
+    ],
+    [
+      ['/route', null],
+      ['/route/', ['/route/', 'route']]
+    ],
+    [
+      [{ test: 'foobar' }, '/foobar/']
+    ]
   ],
 
   /**
    * Arrays of simple paths.
    */
-  [['/one', '/two'], [], '/one', ['/one']],
-  [['/one', '/two'], [], '/two', ['/two']],
-  [['/one', '/two'], [], '/three', null],
-  [['/one', '/two'], [], '/one/two', null],
+  [
+    ['/one', '/two'],
+    null,
+    [],
+    [
+      ['/one', ['/one']],
+      ['/two', ['/two']],
+      ['/three', null],
+      ['/one/two', null]
+    ]
+  ],
 
   /**
    * Non-ending simple path.
    */
-  ['/test', [], '/test/route', ['/test'], { end: false }],
+  [
+    '/test',
+    {
+      end: false
+    },
+    [
+      '/test'
+    ],
+    [
+      ['/test/route', ['/test']]
+    ],
+    [
+      [null, '/test']
+    ]
+  ],
 
   /**
    * Single named parameter.
    */
   [
     '/:test',
-    [{ name: 'test', prefix: '/', delimiter: '/', optional: false, repeat: false, pattern: '[^\\/]+?' }],
-    '/route',
-    ['/route', 'route']
-  ],
-  [
-    '/:test',
-    [{ name: 'test', prefix: '/', delimiter: '/', optional: false, repeat: false, pattern: '[^\\/]+?' }],
-    '/another',
-    ['/another', 'another']
-  ],
-  [
-    '/:test',
-    [{ name: 'test', prefix: '/', delimiter: '/', optional: false, repeat: false, pattern: '[^\\/]+?' }],
-    '/something/else',
-    null
-  ],
-  [
-    '/:test',
-    [{ name: 'test', prefix: '/', delimiter: '/', optional: false, repeat: false, pattern: '[^\\/]+?' }],
-    '/route.json',
-    ['/route.json', 'route.json']
-  ],
-  [
-    '/:test',
-    [{ name: 'test', prefix: '/', delimiter: '/', optional: false, repeat: false, pattern: '[^\\/]+?' }],
-    '/route',
-    ['/route', 'route'],
-    { strict: true }],
-  [
-    '/:test',
-    [{ name: 'test', prefix: '/', delimiter: '/', optional: false, repeat: false, pattern: '[^\\/]+?' }],
-    '/route/',
     null,
-    { strict: true }
+    [
+      {
+        name: 'test',
+        prefix: '/',
+        delimiter: '/',
+        optional: false,
+        repeat: false,
+        pattern: '[^\\/]+?'
+      }
+    ],
+    [
+      ['/route', ['/route', 'route']],
+      ['/another', ['/another', 'another']],
+      ['/something/else', null],
+      ['/route.json', ['/route.json', 'route.json']]
+    ],
+    [
+      [{ test: 'route' }, '/route']
+    ]
+  ],
+  [
+    '/:test',
+    {
+      strict: true
+    },
+    [
+      {
+        name: 'test',
+        prefix: '/',
+        delimiter: '/',
+        optional: false,
+        repeat: false,
+        pattern: '[^\\/]+?'
+      }
+    ],
+    [
+      ['/route', ['/route', 'route']],
+      ['/route/', null]
+    ],
+    [
+      [{ test: 'route' }, '/route']
+    ]
   ],
   [
     '/:test/',
-    [{ name: 'test', prefix: '/', delimiter: '/', optional: false, repeat: false, pattern: '[^\\/]+?' }],
-    '/route/',
-    ['/route/', 'route'],
-    { strict: true }
-  ],
-  [
-    '/:test/',
-    [{ name: 'test', prefix: '/', delimiter: '/', optional: false, repeat: false, pattern: '[^\\/]+?' }],
-    '/route//',
-    null,
-    { strict: true }
+    {
+      strict: true
+    },
+    [
+      {
+        name: 'test',
+        prefix: '/',
+        delimiter: '/',
+        optional: false,
+        repeat: false,
+        pattern: '[^\\/]+?'
+      },
+      '/'
+    ],
+    [
+      ['/route/', ['/route/', 'route']],
+      ['/route//', null]
+    ],
+    [
+      [{ test: 'route' }, '/route/']
+    ]
   ],
   [
     '/:test',
-    [{ name: 'test', prefix: '/', delimiter: '/', optional: false, repeat: false, pattern: '[^\\/]+?' }],
-    '/route.json',
-    ['/route.json', 'route.json'],
-    { end: false }
+    {
+      end: false
+    },
+    [
+      {
+        name: 'test',
+        prefix: '/',
+        delimiter: '/',
+        optional: false,
+        repeat: false,
+        pattern: '[^\\/]+?'
+      }
+    ],
+    [
+      ['/route.json', ['/route.json', 'route.json']],
+      ['/route//', ['/route', 'route']]
+    ],
+    [
+      [{ test: 'route' }, '/route']
+    ]
   ],
 
   /**
@@ -186,105 +466,157 @@ var TESTS = [
    */
   [
     '/:test?',
-    [{ name: 'test', prefix: '/', delimiter: '/', optional: true, repeat: false, pattern: '[^\\/]+?' }],
-    '/route',
-    ['/route', 'route']
-  ],
-  [
-    '/:test?',
-    [{ name: 'test', prefix: '/', delimiter: '/', optional: true, repeat: false, pattern: '[^\\/]+?' }],
-    '/route/nested',
-    null
-  ],
-  [
-    '/:test?',
-    [{ name: 'test', prefix: '/', delimiter: '/', optional: true, repeat: false, pattern: '[^\\/]+?' }],
-    '/',
-    ['/', undefined]
-  ],
-  [
-    '/:test?',
-    [{ name: 'test', prefix: '/', delimiter: '/', optional: true, repeat: false, pattern: '[^\\/]+?' }],
-    '/route',
-    ['/route', 'route'],
-    { strict: true }
-  ],
-  [
-    '/:test?',
-    [{ name: 'test', prefix: '/', delimiter: '/', optional: true, repeat: false, pattern: '[^\\/]+?' }],
-    '/',
-    null, // Questionable behaviour.
-    { strict: true }
-  ],
-  [
-    '/:test?/',
-    [{ name: 'test', prefix: '/', delimiter: '/', optional: true, repeat: false, pattern: '[^\\/]+?' }],
-    '/',
-    ['/', undefined],
-    { strict: true }
-  ],
-  [
-    '/:test?/',
-    [{ name: 'test', prefix: '/', delimiter: '/', optional: true, repeat: false, pattern: '[^\\/]+?' }],
-    '//',
-    null
-  ],
-  [
-    '/:test?/',
-    [{ name: 'test', prefix: '/', delimiter: '/', optional: true, repeat: false, pattern: '[^\\/]+?' }],
-    '//',
     null,
-    { strict: true }
+    [
+      {
+        name: 'test',
+        prefix: '/',
+        delimiter: '/',
+        optional: true,
+        repeat: false,
+        pattern: '[^\\/]+?'
+      }
+    ],
+    [
+      ['/route', ['/route', 'route']],
+      ['/route/nested', null],
+      ['/', ['/', undefined]],
+      ['//', null]
+    ],
+    [
+      [null, ''],
+      [{ test: 'foobar' }, '/foobar']
+    ]
+  ],
+  [
+    '/:test?',
+    {
+      strict: true
+    },
+    [
+      {
+        name: 'test',
+        prefix: '/',
+        delimiter: '/',
+        optional: true,
+        repeat: false,
+        pattern: '[^\\/]+?'
+      }
+    ],
+    [
+      ['/route', ['/route', 'route']],
+      ['/', null], // Questionable behaviour.
+      ['//', null]
+    ],
+    [
+      [null, ''],
+      [{ test: 'foobar' }, '/foobar']
+    ]
+  ],
+  [
+    '/:test?/',
+    {
+      strict: true
+    },
+    [
+      {
+        name: 'test',
+        prefix: '/',
+        delimiter: '/',
+        optional: true,
+        repeat: false,
+        pattern: '[^\\/]+?'
+      },
+      '/'
+    ],
+    [
+      ['/route', null],
+      ['/route/', ['/route/', 'route']],
+      ['/', ['/', undefined]],
+      ['//', null]
+    ],
+    [
+      [null, '/'],
+      [{ test: 'foobar' }, '/foobar/']
+    ]
   ],
 
-  // Repeated once or more times parameters.
+  /**
+   * Repeated one or more times parameters.
+   */
   [
     '/:test+',
-    [{ name: 'test', prefix: '/', delimiter: '/', optional: false, repeat: true, pattern: '[^\\/]+?' }],
-    '/',
-    null
-  ],
-  [
-    '/:test+',
-    [{ name: 'test', prefix: '/', delimiter: '/', optional: false, repeat: true, pattern: '[^\\/]+?' }],
-    '/route',
-    ['/route', 'route']
-  ],
-  [
-    '/:test+',
-    [{ name: 'test', prefix: '/', delimiter: '/', optional: false, repeat: true, pattern: '[^\\/]+?' }],
-    '/some/basic/route',
-    ['/some/basic/route', 'some/basic/route']
+    null,
+    [
+      {
+        name: 'test',
+        prefix: '/',
+        delimiter: '/',
+        optional: false,
+        repeat: true,
+        pattern: '[^\\/]+?'
+      }
+    ],
+    [
+      ['/', null],
+      ['/route', ['/route', 'route']],
+      ['/some/basic/route', ['/some/basic/route', 'some/basic/route']],
+      ['//', null]
+    ],
+    [
+      [{}, null],
+      [{ test: 'foobar' }, '/foobar'],
+      [{ test: ['a', 'b', 'c'] }, '/a/b/c']
+    ]
   ],
   [
     '/:test(\\d+)+',
-    [{ name: 'test', prefix: '/', delimiter: '/', optional: false, repeat: true, pattern: '\\d+' }],
-    '/abc/456/789',
-    null
-  ],
-  [
-    '/:test(\\d+)+',
-    [{ name: 'test', prefix: '/', delimiter: '/', optional: false, repeat: true, pattern: '\\d+' }],
-    '/123/456/789',
-    ['/123/456/789', '123/456/789']
+    null,
+    [
+      {
+        name: 'test',
+        prefix: '/',
+        delimiter: '/',
+        optional: false,
+        repeat: true,
+        pattern: '\\d+'
+      }
+    ],
+    [
+      ['/abc/456/789', null],
+      ['/123/456/789', ['/123/456/789', '123/456/789']]
+    ],
+    [
+      [{ test: 'abc' }, null],
+      [{ test: 123 }, '/123'],
+      [{ test: [1, 2, 3] }, '/1/2/3']
+    ]
   ],
   [
     '/route.:ext(json|xml)+',
-    [{ name: 'ext', prefix: '.', delimiter: '.', optional: false, repeat: true, pattern: 'json|xml' }],
-    '/route.json',
-    ['/route.json', 'json']
-  ],
-  [
-    '/route.:ext(json|xml)+',
-    [{ name: 'ext', prefix: '.', delimiter: '.', optional: false, repeat: true, pattern: 'json|xml' }],
-    '/route.xml.json',
-    ['/route.xml.json', 'xml.json']
-  ],
-  [
-    '/route.:ext(json|xml)+',
-    [{ name: 'ext', prefix: '.', delimiter: '.', optional: false, repeat: true, pattern: 'json|xml' }],
-    '/route.html',
-    null
+    null,
+    [
+      '/route',
+      {
+        name: 'ext',
+        prefix: '.',
+        delimiter: '.',
+        optional: false,
+        repeat: true,
+        pattern: 'json|xml'
+      }
+    ],
+    [
+      ['/route', null],
+      ['/route.json', ['/route.json', 'json']],
+      ['/route.xml.json', ['/route.xml.json', 'xml.json']],
+      ['/route.html', null]
+    ],
+    [
+      [{ ext: 'foobar' }, null],
+      [{ ext: 'xml' }, '/route.xml'],
+      [{ ext: ['xml', 'json'] }, '/route.xml.json']
+    ]
   ],
 
   /**
@@ -292,108 +624,176 @@ var TESTS = [
    */
   [
     '/:test*',
-    [{ name: 'test', prefix: '/', delimiter: '/', optional: true, repeat: true, pattern: '[^\\/]+?' }],
-    '/',
-    ['/', undefined]
-  ],
-  [
-    '/:test*',
-    [{ name: 'test', prefix: '/', delimiter: '/', optional: true, repeat: true, pattern: '[^\\/]+?' }],
-    '//',
-    null
-  ],
-  [
-    '/:test*',
-    [{ name: 'test', prefix: '/', delimiter: '/', optional: true, repeat: true, pattern: '[^\\/]+?' }],
-    '/route',
-    ['/route', 'route']
-  ],
-  [
-    '/:test*',
-    [{ name: 'test', prefix: '/', delimiter: '/', optional: true, repeat: true, pattern: '[^\\/]+?' }],
-    '/some/basic/route',
-    ['/some/basic/route', 'some/basic/route']
-  ],
-  [
-    '/route.:ext([a-z]+)*',
-    [{ name: 'ext', prefix: '.', delimiter: '.', optional: true, repeat: true, pattern: '[a-z]+' }],
-    '/route',
-    ['/route', undefined]
+    null,
+    [
+      {
+        name: 'test',
+        prefix: '/',
+        delimiter: '/',
+        optional: true,
+        repeat: true,
+        pattern: '[^\\/]+?'
+      }
+    ],
+    [
+      ['/', ['/', undefined]],
+      ['//', null],
+      ['/route', ['/route', 'route']],
+      ['/some/basic/route', ['/some/basic/route', 'some/basic/route']]
+    ],
+    [
+      [{}, ''],
+      [{ test: 'foobar' }, '/foobar'],
+      [{ test: ['foo', 'bar'] }, '/foo/bar']
+    ]
   ],
   [
     '/route.:ext([a-z]+)*',
-    [{ name: 'ext', prefix: '.', delimiter: '.', optional: true, repeat: true, pattern: '[a-z]+' }],
-    '/route.json',
-    ['/route.json', 'json']
-  ],
-  [
-    '/route.:ext([a-z]+)*',
-    [{ name: 'ext', prefix: '.', delimiter: '.', optional: true, repeat: true, pattern: '[a-z]+' }],
-    '/route.xml.json',
-    ['/route.xml.json', 'xml.json']
-  ],
-  [
-    '/route.:ext([a-z]+)*',
-    [{ name: 'ext', prefix: '.', delimiter: '.', optional: true, repeat: true, pattern: '[a-z]+' }],
-    '/route.123',
-    null
+    null,
+    [
+      '/route',
+      {
+        name: 'ext',
+        prefix: '.',
+        delimiter: '.',
+        optional: true,
+        repeat: true,
+        pattern: '[a-z]+'
+      }
+    ],
+    [
+      ['/route', ['/route', undefined]],
+      ['/route.json', ['/route.json', 'json']],
+      ['/route.json.xml', ['/route.json.xml', 'json.xml']],
+      ['/route.123', null]
+    ],
+    [
+      [{}, '/route'],
+      [{ ext: [] }, '/route'],
+      [{ ext: '123' }, null],
+      [{ ext: 'foobar' }, '/route.foobar'],
+      [{ ext: ['foo', 'bar'] }, '/route.foo.bar']
+    ]
   ],
 
-  // Custom named parameters.
+  /**
+   * Custom named parameters.
+   */
   [
     '/:test(\\d+)',
-    [{ name: 'test', prefix: '/', delimiter: '/', optional: false, repeat: false, pattern: '\\d+' }],
-    '/123',
-    ['/123', '123']
+    null,
+    [
+      {
+        name: 'test',
+        prefix: '/',
+        delimiter: '/',
+        optional: false,
+        repeat: false,
+        pattern: '\\d+'
+      }
+    ],
+    [
+      ['/123', ['/123', '123']],
+      ['/abc', null],
+      ['/123/abc', null]
+    ],
+    [
+      [{ test: 'abc' }, null],
+      [{ test: '123' }, '/123']
+    ]
   ],
   [
     '/:test(\\d+)',
-    [{ name: 'test', prefix: '/', delimiter: '/', optional: false, repeat: false, pattern: '\\d+' }],
-    '/abc',
-    null
-  ],
-  [
-    '/:test(\\d+)',
-    [{ name: 'test', prefix: '/', delimiter: '/', optional: false, repeat: false, pattern: '\\d+' }],
-    '/123/abc',
-    null
-  ],
-  [
-    '/:test(\\d+)',
-    [{ name: 'test', prefix: '/', delimiter: '/', optional: false, repeat: false, pattern: '\\d+' }],
-    '/123/abc',
-    ['/123', '123'],
-    { end: false }
+    {
+      end: false
+    },
+    [
+      {
+        name: 'test',
+        prefix: '/',
+        delimiter: '/',
+        optional: false,
+        repeat: false,
+        pattern: '\\d+'
+      }
+    ],
+    [
+      ['/123', ['/123', '123']],
+      ['/abc', null],
+      ['/123/abc', ['/123', '123']]
+    ],
+    [
+      [{ test: '123' }, '/123']
+    ]
   ],
   [
     '/:test(.*)',
-    [{ name: 'test', prefix: '/', delimiter: '/', optional: false, repeat: false, pattern: '.*' }],
-    '/anything/goes/here',
-    ['/anything/goes/here', 'anything/goes/here']
+    null,
+    [
+      {
+        name: 'test',
+        prefix: '/',
+        delimiter: '/',
+        optional: false,
+        repeat: false,
+        pattern: '.*'
+      }
+    ],
+    [
+      ['/anything/goes/here', ['/anything/goes/here', 'anything/goes/here']]
+    ],
+    [
+      [{ test: '' }, '/'],
+      [{ test: 'abc' }, '/abc'],
+      [{ test: 'abc/123' }, '/abc%2F123']
+    ]
   ],
   [
     '/:route([a-z]+)',
-    [{ name: 'route', prefix: '/', delimiter: '/', optional: false, repeat: false, pattern: '[a-z]+' }],
-    '/abcde',
-    ['/abcde', 'abcde']
-  ],
-  [
-    '/:route([a-z]+)',
-    [{ name: 'route', prefix: '/', delimiter: '/', optional: false, repeat: false, pattern: '[a-z]+' }],
-    '/12345',
-    null
+    null,
+    [
+      {
+        name: 'route',
+        prefix: '/',
+        delimiter: '/',
+        optional: false,
+        repeat: false,
+        pattern: '[a-z]+'
+      }
+    ],
+    [
+      ['/abcde', ['/abcde', 'abcde']],
+      ['/12345', null]
+    ],
+    [
+      [{ route: '' }, null],
+      [{ route: '123' }, null],
+      [{ route: 'abc' }, '/abc']
+    ]
   ],
   [
     '/:route(this|that)',
-    [{ name: 'route', prefix: '/', delimiter: '/', optional: false, repeat: false, pattern: 'this|that' }],
-    '/this',
-    ['/this', 'this']
-  ],
-  [
-    '/:route(this|that)',
-    [{ name: 'route', prefix: '/', delimiter: '/', optional: false, repeat: false, pattern: 'this|that' }],
-    '/that',
-    ['/that', 'that']
+    null,
+    [
+      {
+        name: 'route',
+        prefix: '/',
+        delimiter: '/',
+        optional: false,
+        repeat: false,
+        pattern: 'this|that'
+      }
+    ],
+    [
+      ['/this', ['/this', 'this']],
+      ['/that', ['/that', 'that']],
+      ['/foo', null]
+    ],
+    [
+      [{ route: 'this' }, '/this'],
+      [{ route: 'foo' }, null],
+      [{ route: 'that' }, '/that']
+    ]
   ],
 
   /**
@@ -401,47 +801,116 @@ var TESTS = [
    */
   [
     'test',
-    [],
-    'test',
-    ['test']
-  ],
-  [
-    ':test',
-    [{ name: 'test', prefix: '', delimiter: '/', optional: false, repeat: false, pattern: '[^\\/]+?' }],
-    'route',
-    ['route', 'route']
-  ],
-  [
-    ':test',
-    [{ name: 'test', prefix: '', delimiter: '/', optional: false, repeat: false, pattern: '[^\\/]+?' }],
-    '/route',
-    null
-  ],
-  [
-    ':test',
-    [{ name: 'test', prefix: '', delimiter: '/', optional: false, repeat: false, pattern: '[^\\/]+?' }],
-    'route/',
-    ['route/', 'route']
-  ],
-  [
-    ':test',
-    [{ name: 'test', prefix: '', delimiter: '/', optional: false, repeat: false, pattern: '[^\\/]+?' }],
-    'route/',
     null,
-    { strict: true }
+    [
+      'test'
+    ],
+    [
+      ['test', ['test']],
+      ['/test', null]
+    ],
+    [
+      [null, 'test']
+    ]
   ],
   [
     ':test',
-    [{ name: 'test', prefix: '', delimiter: '/', optional: false, repeat: false, pattern: '[^\\/]+?' }],
-    'route/',
-    ['route/', 'route'],
-    { end: false }
+    null,
+    [
+      {
+        name: 'test',
+        prefix: '',
+        delimiter: '/',
+        optional: false,
+        repeat: false,
+        pattern: '[^\\/]+?'
+      }
+    ],
+    [
+      ['route', ['route', 'route']],
+      ['/route', null],
+      ['route/', ['route/', 'route']]
+    ],
+    [
+      [{ test: '' }, null],
+      [{}, null],
+      [{ test: null }, null],
+      [{ test: 'route' }, 'route']
+    ]
+  ],
+  [
+    ':test',
+    {
+      strict: true
+    },
+    [
+      {
+        name: 'test',
+        prefix: '',
+        delimiter: '/',
+        optional: false,
+        repeat: false,
+        pattern: '[^\\/]+?'
+      }
+    ],
+    [
+      ['route', ['route', 'route']],
+      ['/route', null],
+      ['route/', null]
+    ],
+    [
+      [{ test: 'route' }, 'route']
+    ]
+  ],
+  [
+    ':test',
+    {
+      end: false
+    },
+    [
+      {
+        name: 'test',
+        prefix: '',
+        delimiter: '/',
+        optional: false,
+        repeat: false,
+        pattern: '[^\\/]+?'
+      }
+    ],
+    [
+      ['route', ['route', 'route']],
+      ['/route', null],
+      ['route/', ['route/', 'route']],
+      ['route/foobar', ['route', 'route']]
+    ],
+    [
+      [{ test: 'route' }, 'route']
+    ]
   ],
   [
     ':test?',
-    [{ name: 'test', prefix: '', delimiter: '/', optional: true, repeat: false, pattern: '[^\\/]+?' }],
-    '',
-    ['', undefined]
+    null,
+    [
+      {
+        name: 'test',
+        prefix: '',
+        delimiter: '/',
+        optional: true,
+        repeat: false,
+        pattern: '[^\\/]+?'
+      }
+    ],
+    [
+      ['route', ['route', 'route']],
+      ['/route', null],
+      ['', ['', undefined]],
+      ['route/foobar', null]
+    ],
+    [
+      [{}, ''],
+      [{ test: '' }, null],
+      [{ test: 'route' }, 'route']
+    ]
   ],
 
   /**
@@ -449,41 +918,40 @@ var TESTS = [
    */
   [
     '/test.json',
-    [],
-    '/test.json',
-    ['/test.json']
-  ],
-  [
-    '/test.json',
-    [],
-    '/route.json',
-    null
-  ],
-  [
-    '/:test.json',
-    [{ name: 'test', prefix: '/', delimiter: '/', optional: false, repeat: false, pattern: '[^\\/]+?' }],
-    '/route.json',
-    ['/route.json', 'route']
+    null,
+    [
+      '/test.json'
+    ],
+    [
+      ['/test.json', ['/test.json']],
+      ['/route.json', null]
+    ],
+    [
+      [{}, '/test.json']
+    ]
   ],
   [
     '/:test.json',
-    [{ name: 'test', prefix: '/', delimiter: '/', optional: false, repeat: false, pattern: '[^\\/]+?' }],
-    '/route.json.json',
-    ['/route.json.json', 'route.json']
-  ],
-  [
-    '/:test.json',
-    [{ name: 'test', prefix: '/', delimiter: '/', optional: false, repeat: false, pattern: '[^\\/]+?' }],
-    '/route.json',
-    ['/route.json', 'route'],
-    { end: false }
-  ],
-  [
-    '/:test.json',
-    [{ name: 'test', prefix: '/', delimiter: '/', optional: false, repeat: false, pattern: '[^\\/]+?' }],
-    '/route.json.json',
-    ['/route.json.json', 'route.json'],
-    { end: false }
+    null,
+    [
+      {
+        name: 'test',
+        prefix: '/',
+        delimiter: '/',
+        optional: false,
+        repeat: false,
+        pattern: '[^\\/]+?'
+      },
+      '.json'
+    ],
+    [
+      ['/test.json', ['/test.json', 'test']],
+      ['/route.json', ['/route.json', 'route']],
+      ['/route.json.json', ['/route.json.json', 'route.json']]
+    ],
+    [
+      [{ test: 'foo' }, '/foo.json']
+    ]
   ],
 
   /**
@@ -491,46 +959,130 @@ var TESTS = [
    */
   [
     '/test.:format',
-    [{ name: 'format', prefix: '.', delimiter: '.', optional: false, repeat: false, pattern: '[^.]+?' }],
-    '/test.html',
-    ['/test.html', 'html']
-  ],
-  [
-    '/test.:format',
-    [{ name: 'format', prefix: '.', delimiter: '.', optional: false, repeat: false, pattern: '[^.]+?' }],
-    '/test.hbs.html',
-    null
+    null,
+    [
+      '/test',
+      {
+        name: 'format',
+        prefix: '.',
+        delimiter: '.',
+        optional: false,
+        repeat: false,
+        pattern: '[^.]+?'
+      }
+    ],
+    [
+      ['/test.html', ['/test.html', 'html']],
+      ['/test.hbs.html', null]
+    ],
+    [
+      [{}, null],
+      [{ format: '' }, null],
+      [{ format: 'foo' }, '/test.foo']
+    ]
   ],
   [
     '/test.:format.:format',
+    null,
     [
-      { name: 'format', prefix: '.', delimiter: '.', optional: false, repeat: false, pattern: '[^.]+?' },
-      { name: 'format', prefix: '.', delimiter: '.', optional: false, repeat: false, pattern: '[^.]+?' }
+      '/test',
+      {
+        name: 'format',
+        prefix: '.',
+        delimiter: '.',
+        optional: false,
+        repeat: false,
+        pattern: '[^.]+?'
+      },
+      {
+        name: 'format',
+        prefix: '.',
+        delimiter: '.',
+        optional: false,
+        repeat: false,
+        pattern: '[^.]+?'
+      }
     ],
-    '/test.hbs.html',
-    ['/test.hbs.html', 'hbs', 'html']
+    [
+      ['/test.html', null],
+      ['/test.hbs.html', ['/test.hbs.html', 'hbs', 'html']]
+    ],
+    [
+      [{ format: 'foo.bar' }, null],
+      [{ format: 'foo' }, '/test.foo.foo']
+    ]
   ],
   [
     '/test.:format+',
+    null,
     [
-      { name: 'format', prefix: '.', delimiter: '.', optional: false, repeat: true, pattern: '[^.]+?' }
+      '/test',
+      {
+        name: 'format',
+        prefix: '.',
+        delimiter: '.',
+        optional: false,
+        repeat: true,
+        pattern: '[^.]+?'
+      }
     ],
-    '/test.hbs.html',
-    ['/test.hbs.html', 'hbs.html']
+    [
+      ['/test.html', ['/test.html', 'html']],
+      ['/test.hbs.html', ['/test.hbs.html', 'hbs.html']]
+    ],
+    [
+      [{ format: [] }, null],
+      [{ format: 'foo' }, '/test.foo'],
+      [{ format: ['foo', 'bar'] }, '/test.foo.bar']
+    ]
   ],
   [
     '/test.:format',
-    [{ name: 'format', prefix: '.', delimiter: '.', optional: false, repeat: false, pattern: '[^.]+?' }],
-    '/test.hbs.html',
-    null,
-    { end: false }
+    {
+      end: false
+    },
+    [
+      '/test',
+      {
+        name: 'format',
+        prefix: '.',
+        delimiter: '.',
+        optional: false,
+        repeat: false,
+        pattern: '[^.]+?'
+      }
+    ],
+    [
+      ['/test.html', ['/test.html', 'html']],
+      ['/test.hbs.html', null]
+    ],
+    [
+      [{ format: 'foo' }, '/test.foo']
+    ]
   ],
   [
     '/test.:format.',
-    [{ name: 'format', prefix: '.', delimiter: '.', optional: false, repeat: false, pattern: '[^.]+?' }],
-    '/test.hbs.html',
     null,
-    { end: false }
+    [
+      '/test',
+      {
+        name: 'format',
+        prefix: '.',
+        delimiter: '.',
+        optional: false,
+        repeat: false,
+        pattern: '[^.]+?'
+      },
+      '.'
+    ],
+    [
+      ['/test.html.', ['/test.html.', 'html']],
+      ['/test.hbs.html', null]
+    ],
+    [
+      [{ format: '' }, null],
+      [{ format: 'foo' }, '/test.foo.']
+    ]
   ],
 
   /**
@@ -538,92 +1090,129 @@ var TESTS = [
    */
   [
     '/:test.:format',
-    [
-      { name: 'test', prefix: '/', delimiter: '/', optional: false, repeat: false, pattern: '[^\\/]+?' },
-      { name: 'format', prefix: '.', delimiter: '.', optional: false, repeat: false, pattern: '[^.]+?' }
-    ],
-    '/route.html',
-    ['/route.html', 'route', 'html']
-  ],
-  [
-    '/:test.:format',
-    [
-      { name: 'test', prefix: '/', delimiter: '/', optional: false, repeat: false, pattern: '[^\\/]+?' },
-      { name: 'format', prefix: '.', delimiter: '.', optional: false, repeat: false, pattern: '[^.]+?' }
-    ],
-    '/route',
-    null
-  ],
-  [
-    '/:test.:format',
-    [
-      { name: 'test', prefix: '/', delimiter: '/', optional: false, repeat: false, pattern: '[^\\/]+?' },
-      { name: 'format', prefix: '.', delimiter: '.', optional: false, repeat: false, pattern: '[^.]+?' }
-    ],
-    '/route',
-    null
-  ],
-  [
-    '/:test.:format?',
-    [
-      { name: 'test', prefix: '/', delimiter: '/', optional: false, repeat: false, pattern: '[^\\/]+?' },
-      { name: 'format', prefix: '.', delimiter: '.', optional: true, repeat: false, pattern: '[^.]+?' }
-    ],
-    '/route',
-    ['/route', 'route', undefined]
-  ],
-  [
-    '/:test.:format?',
-    [
-      { name: 'test', prefix: '/', delimiter: '/', optional: false, repeat: false, pattern: '[^\\/]+?' },
-      { name: 'format', prefix: '.', delimiter: '.', optional: true, repeat: false, pattern: '[^.]+?' }
-    ],
-    '/route.json',
-    ['/route.json', 'route', 'json']
-  ],
-  [
-    '/:test.:format?',
-    [
-      { name: 'test', prefix: '/', delimiter: '/', optional: false, repeat: false, pattern: '[^\\/]+?' },
-      { name: 'format', prefix: '.', delimiter: '.', optional: true, repeat: false, pattern: '[^.]+?' }
-    ],
-    '/route',
-    ['/route', 'route', undefined],
-    { end: false }
-  ],
-  [
-    '/:test.:format?',
-    [
-      { name: 'test', prefix: '/', delimiter: '/', optional: false, repeat: false, pattern: '[^\\/]+?' },
-      { name: 'format', prefix: '.', delimiter: '.', optional: true, repeat: false, pattern: '[^.]+?' }
-    ],
-    '/route.json',
-    ['/route.json', 'route', 'json'],
-    { end: false }
-  ],
-  [
-    '/:test.:format?',
-    [
-      { name: 'test', prefix: '/', delimiter: '/', optional: false, repeat: false, pattern: '[^\\/]+?' },
-      { name: 'format', prefix: '.', delimiter: '.', optional: true, repeat: false, pattern: '[^.]+?' }
-    ],
-    '/route.json.html',
-    ['/route.json.html', 'route.json', 'html'],
-    { end: false }
-  ],
-  [
-    '/test.:format(.*)z',
-    [{ name: 'format', prefix: '.', delimiter: '.', optional: false, repeat: false, pattern: '.*' }],
-    '/test.abc',
     null,
-    { end: false }
+    [
+      {
+        name: 'test',
+        prefix: '/',
+        delimiter: '/',
+        optional: false,
+        repeat: false,
+        pattern: '[^\\/]+?'
+      },
+      {
+        name: 'format',
+        prefix: '.',
+        delimiter: '.',
+        optional: false,
+        repeat: false,
+        pattern: '[^.]+?'
+      }
+    ],
+    [
+      ['/route.html', ['/route.html', 'route', 'html']],
+      ['/route', null],
+      ['/route.html.json', ['/route.html.json', 'route.html', 'json']]
+    ],
+    [
+      [{}, null],
+      [{ test: 'route', format: 'foo' }, '/route.foo']
+    ]
+  ],
+  [
+    '/:test.:format?',
+    null,
+    [
+      {
+        name: 'test',
+        prefix: '/',
+        delimiter: '/',
+        optional: false,
+        repeat: false,
+        pattern: '[^\\/]+?'
+      },
+      {
+        name: 'format',
+        prefix: '.',
+        delimiter: '.',
+        optional: true,
+        repeat: false,
+        pattern: '[^.]+?'
+      }
+    ],
+    [
+      ['/route', ['/route', 'route', undefined]],
+      ['/route.json', ['/route.json', 'route', 'json']],
+      ['/route.json.html', ['/route.json.html', 'route.json', 'html']]
+    ],
+    [
+      [{ test: 'route' }, '/route'],
+      [{ test: 'route', format: '' }, null],
+      [{ test: 'route', format: 'foo' }, '/route.foo']
+    ]
+  ],
+  [
+    '/:test.:format?',
+    {
+      end: false
+    },
+    [
+      {
+        name: 'test',
+        prefix: '/',
+        delimiter: '/',
+        optional: false,
+        repeat: false,
+        pattern: '[^\\/]+?'
+      },
+      {
+        name: 'format',
+        prefix: '.',
+        delimiter: '.',
+        optional: true,
+        repeat: false,
+        pattern: '[^.]+?'
+      }
+    ],
+    [
+      ['/route', ['/route', 'route', undefined]],
+      ['/route.json', ['/route.json', 'route', 'json']],
+      ['/route.json.html', ['/route.json.html', 'route.json', 'html']]
+    ],
+    [
+      [{ test: 'route' }, '/route'],
+      [{ test: 'route', format: undefined }, '/route'],
+      [{ test: 'route', format: '' }, null],
+      [{ test: 'route', format: 'foo' }, '/route.foo']
+    ]
   ],
   [
     '/test.:format(.*)z',
-    [{ name: 'format', prefix: '.', delimiter: '.', optional: false, repeat: false, pattern: '.*' }],
-    '/test.abcz',
-    ['/test.abcz', 'abc'],
-    { end: false }
+    {
+      end: false
+    },
+    [
+      '/test',
+      {
+        name: 'format',
+        prefix: '.',
+        delimiter: '.',
+        optional: false,
+        repeat: false,
+        pattern: '.*'
+      },
+      'z'
+    ],
+    [
+      ['/test.abc', null],
+      ['/test.z', ['/test.z', '']],
+      ['/test.abcz', ['/test.abcz', 'abc']]
+    ],
+    [
+      [{}, null],
+      [{ format: '' }, '/test.z'],
+      [{ format: 'foo' }, '/test.fooz']
+    ]
   ],
 
   /**
@@ -631,59 +1220,96 @@ var TESTS = [
    */
   [
     '/(\\d+)',
-    [{ name: 0, prefix: '/', delimiter: '/', optional: false, repeat: false, pattern: '\\d+' }],
-    '/123',
-    ['/123', '123']
-  ],
-  [
-    '/(\\d+)',
-    [{ name: 0, prefix: '/', delimiter: '/', optional: false, repeat: false, pattern: '\\d+' }],
-    '/abc',
-    null
-  ],
-  [
-    '/(\\d+)',
-    [{ name: 0, prefix: '/', delimiter: '/', optional: false, repeat: false, pattern: '\\d+' }],
-    '/123/abc',
-    null
-  ],
-  [
-    '/(\\d+)',
-    [{ name: 0, prefix: '/', delimiter: '/', optional: false, repeat: false, pattern: '\\d+' }],
-    '/123/abc',
-    ['/123', '123'],
-    { end: false }
-  ],
-  [
-    '/(\\d+)',
-    [{ name: 0, prefix: '/', delimiter: '/', optional: false, repeat: false, pattern: '\\d+' }],
-    '/abc',
     null,
-    { end: false }
+    [
+      {
+        name: 0,
+        prefix: '/',
+        delimiter: '/',
+        optional: false,
+        repeat: false,
+        pattern: '\\d+'
+      }
+    ],
+    [
+      ['/123', ['/123', '123']],
+      ['/abc', null],
+      ['/123/abc', null]
+    ],
+    [
+      [{}, null],
+      [{ '0': '123' }, '/123']
+    ]
+  ],
+  [
+    '/(\\d+)',
+    {
+      end: false
+    },
+    [
+      {
+        name: 0,
+        prefix: '/',
+        delimiter: '/',
+        optional: false,
+        repeat: false,
+        pattern: '\\d+'
+      }
+    ],
+    [
+      ['/123', ['/123', '123']],
+      ['/abc', null],
+      ['/123/abc', ['/123', '123']],
+      ['/123/', ['/123/', '123']]
+    ],
+    [
+      [{ '0': '123' }, '/123']
+    ]
   ],
   [
     '/(\\d+)?',
-    [{ name: 0, prefix: '/', delimiter: '/', optional: true, repeat: false, pattern: '\\d+' }],
-    '/',
-    ['/', undefined]
-  ],
-  [
-    '/(\\d+)?',
-    [{ name: 0, prefix: '/', delimiter: '/', optional: true, repeat: false, pattern: '\\d+' }],
-    '/123',
-    ['/123', '123']
+    null,
+    [
+      {
+        name: 0,
+        prefix: '/',
+        delimiter: '/',
+        optional: true,
+        repeat: false,
+        pattern: '\\d+'
+      }
+    ],
+    [
+      ['/', ['/', undefined]],
+      ['/123', ['/123', '123']]
+    ],
+    [
+      [{}, ''],
+      [{ '0': '123' }, '/123']
+    ]
   ],
   [
     '/(.*)',
-    [{ name: 0, prefix: '/', delimiter: '/', optional: false, repeat: false, pattern: '.*' }],
-    '/route',
-    ['/route', 'route']
-  ],
-  [
-    '/(.*)',
-    [{ name: 0, prefix: '/', delimiter: '/', optional: false, repeat: false, pattern: '.*' }],
-    '/route/nested',
-    ['/route/nested', 'route/nested']
+    null,
+    [
+      {
+        name: 0,
+        prefix: '/',
+        delimiter: '/',
+        optional: false,
+        repeat: false,
+        pattern: '.*'
+      }
+    ],
+    [
+      ['/', ['/', '']],
+      ['/route', ['/route', 'route']],
+      ['/route/nested', ['/route/nested', 'route/nested']]
+    ],
+    [
+      [{ '0': '' }, '/'],
+      [{ '0': '123' }, '/123']
+    ]
   ],
 
   /**
@@ -691,21 +1317,46 @@ var TESTS = [
    */
   [
     /.*/,
+    null,
     [],
-    '/match/anything',
-    ['/match/anything']
+    [
+      ['/match/anything', ['/match/anything']]
+    ]
   ],
   [
     /(.*)/,
-    [{ name: 0, prefix: null, delimiter: null, optional: false, repeat: false, pattern: null }],
-    '/match/anything',
-    ['/match/anything', '/match/anything']
+    null,
+    [
+      {
+        name: 0,
+        prefix: null,
+        delimiter: null,
+        optional: false,
+        repeat: false,
+        pattern: null
+      }
+    ],
+    [
+      ['/match/anything', ['/match/anything', '/match/anything']]
+    ]
   ],
   [
     /\/(\d+)/,
-    [{ name: 0, prefix: null, delimiter: null, optional: false, repeat: false, pattern: null }],
-    '/123',
-    ['/123', '123']
+    null,
+    [
+      {
+        name: 0,
+        prefix: null,
+        delimiter: null,
+        optional: false,
+        repeat: false,
+        pattern: null
+      }
+    ],
+    [
+      ['/abc', null],
+      ['/123', ['/123', '123']]
+    ]
   ],
 
   /**
@@ -713,27 +1364,46 @@ var TESTS = [
    */
   [
     ['/test', /\/(\d+)/],
-    [{ name: 0, prefix: null, delimiter: null, optional: false, repeat: false, pattern: null }],
-    '/test',
-    ['/test', undefined]
+    null,
+    [
+      {
+        name: 0,
+        prefix: null,
+        delimiter: null,
+        optional: false,
+        repeat: false,
+        pattern: null
+      }
+    ],
+    [
+      ['/test', ['/test', undefined]]
+    ]
   ],
   [
     ['/:test(\\d+)', /(.*)/],
+    null,
     [
-      { name: 'test', prefix: '/', delimiter: '/', optional: false, repeat: false, pattern: '\\d+' },
-      { name: 0, prefix: null, delimiter: null, optional: false, repeat: false, pattern: null }
+      {
+        name: 'test',
+        prefix: '/',
+        delimiter: '/',
+        optional: false,
+        repeat: false,
+        pattern: '\\d+'
+      },
+      {
+        name: 0,
+        prefix: null,
+        delimiter: null,
+        optional: false,
+        repeat: false,
+        pattern: null
+      }
     ],
-    '/123',
-    ['/123', '123', undefined]
-  ],
-  [
-    ['/:test(\\d+)', /(.*)/],
     [
-      { name: 'test', prefix: '/', delimiter: '/', optional: false, repeat: false, pattern: '\\d+' },
-      { name: 0, prefix: null, delimiter: null, optional: false, repeat: false, pattern: null }
-    ],
-    '/abc',
-    ['/abc', undefined, '/abc']
+      ['/123', ['/123', '123', undefined]],
+      ['/abc', ['/abc', undefined, '/abc']]
+    ]
   ],
 
   /**
@@ -741,39 +1411,55 @@ var TESTS = [
    */
   [
     ['/:test', '/route/:test'],
+    null,
     [
-      { name: 'test', prefix: '/', delimiter: '/', optional: false, repeat: false, pattern: '[^\\/]+?' },
-      { name: 'test', prefix: '/', delimiter: '/', optional: false, repeat: false, pattern: '[^\\/]+?' }
+      {
+        name: 'test',
+        prefix: '/',
+        delimiter: '/',
+        optional: false,
+        repeat: false,
+        pattern: '[^\\/]+?'
+      },
+      {
+        name: 'test',
+        prefix: '/',
+        delimiter: '/',
+        optional: false,
+        repeat: false,
+        pattern: '[^\\/]+?'
+      }
     ],
-    '/test',
-    ['/test', 'test', undefined]
-  ],
-  [
-    ['/:test', '/route/:test'],
     [
-      { name: 'test', prefix: '/', delimiter: '/', optional: false, repeat: false, pattern: '[^\\/]+?' },
-      { name: 'test', prefix: '/', delimiter: '/', optional: false, repeat: false, pattern: '[^\\/]+?' }
-    ],
-    '/route/test',
-    ['/route/test', undefined, 'test']
+      ['/test', ['/test', 'test', undefined]],
+      ['/route/test', ['/route/test', undefined, 'test']]
+    ]
   ],
   [
     [/^\/([^\/]+)$/, /^\/route\/([^\/]+)$/],
+    null,
     [
-      { name: 0, prefix: null, delimiter: null, optional: false, repeat: false, pattern: null },
-      { name: 0, prefix: null, delimiter: null, optional: false, repeat: false, pattern: null }
+      {
+        name: 0,
+        prefix: null,
+        delimiter: null,
+        optional: false,
+        repeat: false,
+        pattern: null
+      },
+      {
+        name: 0,
+        prefix: null,
+        delimiter: null,
+        optional: false,
+        repeat: false,
+        pattern: null
+      }
     ],
-    '/test',
-    ['/test', 'test', undefined]
-  ],
-  [
-    [/^\/([^\/]+)$/, /^\/route\/([^\/]+)$/],
     [
-      { name: 0, prefix: null, delimiter: null, optional: false, repeat: false, pattern: null },
-      { name: 0, prefix: null, delimiter: null, optional: false, repeat: false, pattern: null }
-    ],
-    '/route/test',
-    ['/route/test', undefined, 'test']
+      ['/test', ['/test', 'test', undefined]],
+      ['/route/test', ['/route/test', undefined, 'test']]
+    ]
   ],
 
   /**
@@ -781,9 +1467,11 @@ var TESTS = [
    */
   [
     /(?:.*)/,
+    null,
     [],
-    '/anything/you/want',
-    ['/anything/you/want']
+    [
+      ['/anything/you/want', ['/anything/you/want']]
+    ]
   ],
 
   /**
@@ -791,51 +1479,138 @@ var TESTS = [
    */
   [
     '/\\(testing\\)',
-    [],
-    '/testing',
-    null
-  ],
-  [
-    '/\\(testing\\)',
-    [],
-    '/(testing)',
-    ['/(testing)']
+    null,
+    [
+      '/(testing)'
+    ],
+    [
+      ['/testing', null],
+      ['/(testing)', ['/(testing)']]
+    ],
+    [
+      [null, '/(testing)']
+    ]
   ],
   [
     '/.+*?=^!:${}[]|',
-    [],
-    '/.+*?=^!:${}[]|',
-    ['/.+*?=^!:${}[]|']
+    null,
+    [
+      '/.+*?=^!:${}[]|'
+    ],
+    [
+      ['/.+*?=^!:${}[]|', ['/.+*?=^!:${}[]|']]
+    ],
+    [
+      [null, '/.+*?=^!:${}[]|']
+    ]
   ],
 
   /**
-   * Real world examples.
+   * Random examples.
    */
   [
     '/:foo/:bar',
+    null,
     [
-      { name: 'foo', prefix: '/', delimiter: '/', optional: false, repeat: false, pattern: '[^\\/]+?' },
-      { name: 'bar', prefix: '/', delimiter: '/', optional: false, repeat: false, pattern: '[^\\/]+?' }
+      {
+        name: 'foo',
+        prefix: '/',
+        delimiter: '/',
+        optional: false,
+        repeat: false,
+        pattern: '[^\\/]+?'
+      },
+      {
+        name: 'bar',
+        prefix: '/',
+        delimiter: '/',
+        optional: false,
+        repeat: false,
+        pattern: '[^\\/]+?'
+      }
     ],
-    '/match/route',
-    ['/match/route', 'match', 'route']
+    [
+      ['/match/route', ['/match/route', 'match', 'route']]
+    ],
+    [
+      [{ foo: 'a', bar: 'b' }, '/a/b']
+    ]
   ],
   [
     '/:remote([\\w-.]+)/:user([\\w-]+)',
+    null,
     [
-      { name: 'remote', prefix: '/', delimiter: '/', optional: false, repeat: false, pattern: '[\\w-.]+' },
-      { name: 'user', prefix: '/', delimiter: '/', optional: false, repeat: false, pattern: '[\\w-]+' }
+      {
+        name: 'remote',
+        prefix: '/',
+        delimiter: '/',
+        optional: false,
+        repeat: false,
+        pattern: '[\\w-.]+'
+      },
+      {
+        name: 'user',
+        prefix: '/',
+        delimiter: '/',
+        optional: false,
+        repeat: false,
+        pattern: '[\\w-]+'
+      }
     ],
-    '/endpoint/user',
-    ['/endpoint/user', 'endpoint', 'user']
+    [
+      ['/endpoint/user', ['/endpoint/user', 'endpoint', 'user']],
+      ['/endpoint/user-name', ['/endpoint/user-name', 'endpoint', 'user-name']],
+      ['/foo.bar/user-name', ['/foo.bar/user-name', 'foo.bar', 'user-name']]
+    ],
+    [
+      [{ remote: 'foo', user: 'bar' }, '/foo/bar'],
+      [{ remote: 'foo.bar', user: 'uno' }, '/foo.bar/uno']
+    ]
   ],
   [
     '/:foo\\?',
+    null,
     [
-      { name: 'foo', prefix: '/', delimiter: '/', optional: false, repeat: false, pattern: '[^\\/]+?' }
+      {
+        name: 'foo',
+        prefix: '/',
+        delimiter: '/',
+        optional: false,
+        repeat: false,
+        pattern: '[^\\/]+?'
+      },
+      '?'
     ],
-    '/route?',
-    ['/route?', 'route']
+    [
+      ['/route?', ['/route?', 'route']]
+    ],
+    [
+      [{ foo: 'bar' }, '/bar?']
+    ]
+  ],
+
+  /**
+   * Unicode characters.
+   */
+  [
+    '/:foo',
+    null,
+    [
+      {
+        name: 'foo',
+        prefix: '/',
+        delimiter: '/',
+        optional: false,
+        repeat: false,
+        pattern: '[^\\/]+?'
+      }
+    ],
+    [
+      ['/café', ['/café', 'café']]
+    ],
+    [
+      [{ foo: 'café' }, '/caf%C3%A9']
+    ]
   ]
 ]
 
@@ -854,33 +1629,84 @@ describe('path-to-regexp', function () {
     pattern: '[^\\/]+?'
   }
 
-  describe('parse', function () {
-    it('should parse the string', function () {
-      var tokens = pathToRegexp.parse(TEST_PATH)
+  describe('arguments', function () {
+    it('should accept an array of keys as the second argument', function () {
+      var keys = []
+      var re = pathToRegexp(TEST_PATH, keys, { end: false })
 
-      expect(tokens).to.deep.equal(['/user', TEST_PARAM])
+      expect(re.keys).to.equal(keys)
+      expect(keys).to.deep.equal([TEST_PARAM])
+      expect(exec(re, '/user/123/show')).to.deep.equal(['/user/123', '123'])
+    })
+
+    it('should work with keys as null', function () {
+      var re = pathToRegexp(TEST_PATH, null, { end: false })
+
+      expect(re.keys).to.deep.equal([TEST_PARAM])
+      expect(exec(re, '/user/123/show')).to.deep.equal(['/user/123', '123'])
     })
   })
 
-  describe('compile', function () {
-    it('should compile a path into a function for reversing', function () {
-      var toPath = pathToRegexp.compile(TEST_PATH)
+  describe('rules', function () {
+    TESTS.forEach(function (test) {
+      var path = test[0]
+      var opts = test[1]
+      var tokens = test[2]
+      var matchCases = test[3]
+      var compileCases = test[4]
 
-      expect(toPath({ id: 123 })).to.equal('/user/123')
+      var keys = tokens.filter(function (token) {
+        return typeof token !== 'string'
+      })
+
+      describe(util.inspect(path), function () {
+        // Parsing and compiling is only supported with string input.
+        if (typeof path === 'string') {
+          it('should parse', function () {
+            expect(pathToRegexp.parse(path)).to.deep.equal(tokens)
+          })
+
+          describe('compile', function () {
+            var toPath = pathToRegexp.compile(path)
+
+            compileCases.forEach(function (io) {
+              var input = io[0]
+              var output = io[1]
+
+              if (output != null) {
+                it('should compile using ' + util.inspect(input), function () {
+                  expect(toPath(input)).to.equal(output)
+                })
+              } else {
+                it('should not compile using ' + util.inspect(input), function () {
+                  expect(function () {
+                    toPath(input)
+                  }).to.throw(TypeError)
+                })
+              }
+            })
+          })
+        }
+
+        describe('match' + (opts ? ' using ' + util.inspect(opts) : ''), function () {
+          matchCases.forEach(function (io) {
+            var input = io[0]
+            var output = io[1]
+            var message = 'should' + (output ? ' ' : ' not ') + 'match ' + util.inspect(input)
+
+            it(message, function () {
+              var re = pathToRegexp(path, opts)
+
+              expect(re.keys).to.deep.equal(keys)
+              expect(exec(re, input)).to.deep.equal(output)
+            })
+          })
+        })
+      })
     })
+  })
 
-    it('should generate path without parameters', function () {
-      var toPath = pathToRegexp.compile('/user')
-
-      expect(toPath()).to.equal('/user')
-    })
-
-    it('should omit optional parameters', function () {
-      var toPath = pathToRegexp.compile('/a/:b?/c')
-
-      expect(toPath()).to.equal('/a/c')
-    })
-
+  describe('compile errors', function () {
     it('should throw when a required param is undefined', function () {
       var toPath = pathToRegexp.compile('/a/:b/c')
 
@@ -889,24 +1715,12 @@ describe('path-to-regexp', function () {
       }).to.throw(TypeError, 'Expected "b" to be defined')
     })
 
-    it('should encode path parameters', function () {
-      var toPath = pathToRegexp.compile('/:foo')
-
-      expect(toPath({ foo: 'café' })).to.equal('/caf%C3%A9')
-    })
-
     it('should throw when it does not match the pattern', function () {
       var toPath = pathToRegexp.compile('/:foo(\\d+)')
 
       expect(function () {
         toPath({ foo: 'abc' })
       }).to.throw(TypeError, 'Expected "foo" to match "\\d+"')
-    })
-
-    it('should handle repeated values', function () {
-      var toPath = pathToRegexp.compile('/:foo+')
-
-      expect(toPath({ foo: [1, 2, 3] })).to.equal('/1/2/3')
     })
 
     it('should throw when expecting a repeated value', function () {
@@ -931,74 +1745,6 @@ describe('path-to-regexp', function () {
       expect(function () {
         toPath({ foo: [1, 2, 3, 'a'] })
       }).to.throw(TypeError, 'Expected all "foo" to match "\\d+"')
-    })
-
-    it('should allow optional repeated values', function () {
-      var toPath = pathToRegexp.compile('/user/:id(\\d+)*')
-
-      expect(toPath()).to.equal('/user')
-    })
-
-    it('should allow optional repeated values to be empty arrays', function () {
-      var toPath = pathToRegexp.compile('/user/:id(\\d+)*')
-
-      expect(toPath({ id: [] })).to.equal('/user')
-    })
-
-    it('should handle optional repeated parameters', function () {
-      var toPath = pathToRegexp.compile('/a/:b*/c')
-
-      expect(toPath({ b: [1, 2, 3] })).to.equal('/a/1/2/3/c')
-    })
-  })
-
-  describe('arguments', function () {
-    it('should work without second keys', function () {
-      var re = pathToRegexp(TEST_PATH, { end: false })
-
-      expect(re.keys).to.deep.equal([TEST_PARAM])
-      expect(exec(re, '/user/123/show')).to.deep.equal(['/user/123', '123'])
-    })
-
-    it('should work with keys as null', function () {
-      var re = pathToRegexp(TEST_PATH, null, { end: false })
-
-      expect(re.keys).to.deep.equal([TEST_PARAM])
-      expect(exec(re, '/user/123/show')).to.deep.equal(['/user/123', '123'])
-    })
-  })
-
-  describe('rules', function () {
-    TESTS.forEach(function (test) {
-      var description = ''
-      var options = test[4] || {}
-
-      // Generate a base description using the test values.
-      description += 'should ' + (test[3] ? '' : 'not ') + 'match '
-      description += util.inspect(test[2]) + ' against ' + util.inspect(test[0])
-
-      // If additional options have been defined, we should render the options
-      // in the test descriptions.
-      if (Object.keys(options).length) {
-        var optionsDescription = Object.keys(options).map(function (key) {
-          return (options[key] === false ? 'non-' : '') + key
-        }).join(', ')
-
-        description += ' in ' + optionsDescription + ' mode'
-      }
-
-      // Execute the test and check each parameter is as expected.
-      it(description, function () {
-        var keys = []
-        var re = pathToRegexp(test[0], keys, test[4])
-
-        // Check the keys match each other and the expected output.
-        expect(re.keys).to.equal(keys)
-        expect(keys).to.deep.equal(test[1])
-
-        // Run the regexp and check the result as expected.
-        expect(exec(re, test[2])).to.deep.equal(test[3])
-      })
     })
   })
 })

--- a/test.js
+++ b/test.js
@@ -1,21 +1,8 @@
 /* global describe, it */
 
 var util = require('util')
-var assert = require('assert')
+var expect = require('chai').expect
 var pathToRegexp = require('./')
-
-/**
- * Execute a regular expression and return a flat array for comparison.
- *
- * @param  {RegExp} re
- * @param  {String} str
- * @return {Array}
- */
-function exec (re, str) {
-  var match = re.exec(str)
-
-  return match && Array.prototype.slice.call(match)
-}
 
 /**
  * An array of test cases with expected inputs and outputs. The format of each
@@ -65,14 +52,14 @@ var TESTS = [
   ['/test/', [], '/test//route', ['/test'], { end: false }],
   [
     '/:test',
-    [{ name: 'test', delimiter: '/', optional: false, repeat: false, offset: 1, length: 5 }],
+    [{ name: 'test', delimiter: '/', optional: false, repeat: false }],
     '/route',
     ['/route', 'route'],
     { end: false }
   ],
   [
     '/:test/',
-    [{ name: 'test', delimiter: '/', optional: false, repeat: false, offset: 1, length: 5 }],
+    [{ name: 'test', delimiter: '/', optional: false, repeat: false }],
     '/route',
     ['/route', 'route'],
     { end: false }
@@ -92,28 +79,28 @@ var TESTS = [
   ['/test.json', [], '/test.json.hbs', null, { end: false, strict: true }],
   [
     '/:test',
-    [{ name: 'test', delimiter: '/', optional: false, repeat: false, offset: 1, length: 5 }],
+    [{ name: 'test', delimiter: '/', optional: false, repeat: false }],
     '/route',
     ['/route', 'route'],
     { end: false, strict: true }
   ],
   [
     '/:test',
-    [{ name: 'test', delimiter: '/', optional: false, repeat: false, offset: 1, length: 5 }],
+    [{ name: 'test', delimiter: '/', optional: false, repeat: false }],
     '/route/',
     ['/route', 'route'],
     { end: false, strict: true }
   ],
   [
     '/:test/',
-    [{ name: 'test', delimiter: '/', optional: false, repeat: false, offset: 1, length: 5 }],
+    [{ name: 'test', delimiter: '/', optional: false, repeat: false }],
     '/route/',
     ['/route/', 'route'],
     { end: false, strict: true }
   ],
   [
     '/:test/',
-    [{ name: 'test', delimiter: '/', optional: false, repeat: false, offset: 1, length: 5 }],
+    [{ name: 'test', delimiter: '/', optional: false, repeat: false }],
     '/route',
     null,
     { end: false, strict: true }
@@ -137,58 +124,58 @@ var TESTS = [
    */
   [
     '/:test',
-    [{ name: 'test', delimiter: '/', optional: false, repeat: false, offset: 1, length: 5 }],
+    [{ name: 'test', delimiter: '/', optional: false, repeat: false }],
     '/route',
     ['/route', 'route']
   ],
   [
     '/:test',
-    [{ name: 'test', delimiter: '/', optional: false, repeat: false, offset: 1, length: 5 }],
+    [{ name: 'test', delimiter: '/', optional: false, repeat: false }],
     '/another',
     ['/another', 'another']
   ],
   [
     '/:test',
-    [{ name: 'test', delimiter: '/', optional: false, repeat: false, offset: 1, length: 5 }],
+    [{ name: 'test', delimiter: '/', optional: false, repeat: false }],
     '/something/else',
     null
   ],
   [
     '/:test',
-    [{ name: 'test', delimiter: '/', optional: false, repeat: false, offset: 1, length: 5 }],
+    [{ name: 'test', delimiter: '/', optional: false, repeat: false }],
     '/route.json',
     ['/route.json', 'route.json']
   ],
   [
     '/:test',
-    [{ name: 'test', delimiter: '/', optional: false, repeat: false, offset: 1, length: 5 }],
+    [{ name: 'test', delimiter: '/', optional: false, repeat: false }],
     '/route',
     ['/route', 'route'],
     { strict: true }],
   [
     '/:test',
-    [{ name: 'test', delimiter: '/', optional: false, repeat: false, offset: 1, length: 5 }],
+    [{ name: 'test', delimiter: '/', optional: false, repeat: false }],
     '/route/',
     null,
     { strict: true }
   ],
   [
     '/:test/',
-    [{ name: 'test', delimiter: '/', optional: false, repeat: false, offset: 1, length: 5 }],
+    [{ name: 'test', delimiter: '/', optional: false, repeat: false }],
     '/route/',
     ['/route/', 'route'],
     { strict: true }
   ],
   [
     '/:test/',
-    [{ name: 'test', delimiter: '/', optional: false, repeat: false, offset: 1, length: 5 }],
+    [{ name: 'test', delimiter: '/', optional: false, repeat: false }],
     '/route//',
     null,
     { strict: true }
   ],
   [
     '/:test',
-    [{ name: 'test', delimiter: '/', optional: false, repeat: false, offset: 1, length: 5 }],
+    [{ name: 'test', delimiter: '/', optional: false, repeat: false }],
     '/route.json',
     ['/route.json', 'route.json'],
     { end: false }
@@ -199,52 +186,52 @@ var TESTS = [
    */
   [
     '/:test?',
-    [{ name: 'test', delimiter: '/', optional: true, repeat: false, offset: 1, length: 6 }],
+    [{ name: 'test', delimiter: '/', optional: true, repeat: false }],
     '/route',
     ['/route', 'route']
   ],
   [
     '/:test?',
-    [{ name: 'test', delimiter: '/', optional: true, repeat: false, offset: 1, length: 6 }],
+    [{ name: 'test', delimiter: '/', optional: true, repeat: false }],
     '/route/nested',
     null
   ],
   [
     '/:test?',
-    [{ name: 'test', delimiter: '/', optional: true, repeat: false, offset: 1, length: 6 }],
+    [{ name: 'test', delimiter: '/', optional: true, repeat: false }],
     '/',
     ['/', undefined]
   ],
   [
     '/:test?',
-    [{ name: 'test', delimiter: '/', optional: true, repeat: false, offset: 1, length: 6 }],
+    [{ name: 'test', delimiter: '/', optional: true, repeat: false }],
     '/route',
     ['/route', 'route'],
     { strict: true }
   ],
   [
     '/:test?',
-    [{ name: 'test', delimiter: '/', optional: true, repeat: false, offset: 1, length: 6 }],
+    [{ name: 'test', delimiter: '/', optional: true, repeat: false }],
     '/',
     null, // Questionable behaviour.
     { strict: true }
   ],
   [
     '/:test?/',
-    [{ name: 'test', delimiter: '/', optional: true, repeat: false, offset: 1, length: 6 }],
+    [{ name: 'test', delimiter: '/', optional: true, repeat: false }],
     '/',
     ['/', undefined],
     { strict: true }
   ],
   [
     '/:test?/',
-    [{ name: 'test', delimiter: '/', optional: true, repeat: false, offset: 1, length: 6 }],
+    [{ name: 'test', delimiter: '/', optional: true, repeat: false }],
     '//',
     null
   ],
   [
     '/:test?/',
-    [{ name: 'test', delimiter: '/', optional: true, repeat: false, offset: 1, length: 6 }],
+    [{ name: 'test', delimiter: '/', optional: true, repeat: false }],
     '//',
     null,
     { strict: true }
@@ -253,49 +240,49 @@ var TESTS = [
   // Repeated once or more times parameters.
   [
     '/:test+',
-    [{ name: 'test', delimiter: '/', optional: false, repeat: true, offset: 1, length: 6 }],
+    [{ name: 'test', delimiter: '/', optional: false, repeat: true }],
     '/',
     null
   ],
   [
     '/:test+',
-    [{ name: 'test', delimiter: '/', optional: false, repeat: true, offset: 1, length: 6 }],
+    [{ name: 'test', delimiter: '/', optional: false, repeat: true }],
     '/route',
     ['/route', 'route']
   ],
   [
     '/:test+',
-    [{ name: 'test', delimiter: '/', optional: false, repeat: true, offset: 1, length: 6 }],
+    [{ name: 'test', delimiter: '/', optional: false, repeat: true }],
     '/some/basic/route',
     ['/some/basic/route', 'some/basic/route']
   ],
   [
     '/:test(\\d+)+',
-    [{ name: 'test', delimiter: '/', optional: false, repeat: true, offset: 1, length: 11 }],
+    [{ name: 'test', delimiter: '/', optional: false, repeat: true }],
     '/abc/456/789',
     null
   ],
   [
     '/:test(\\d+)+',
-    [{ name: 'test', delimiter: '/', optional: false, repeat: true, offset: 1, length: 11 }],
+    [{ name: 'test', delimiter: '/', optional: false, repeat: true }],
     '/123/456/789',
     ['/123/456/789', '123/456/789']
   ],
   [
     '/route.:ext(json|xml)+',
-    [{ name: 'ext', delimiter: '.', optional: false, repeat: true, offset: 7, length: 15 }],
+    [{ name: 'ext', delimiter: '.', optional: false, repeat: true }],
     '/route.json',
     ['/route.json', 'json']
   ],
   [
     '/route.:ext(json|xml)+',
-    [{ name: 'ext', delimiter: '.', optional: false, repeat: true, offset: 7, length: 15 }],
+    [{ name: 'ext', delimiter: '.', optional: false, repeat: true }],
     '/route.xml.json',
     ['/route.xml.json', 'xml.json']
   ],
   [
     '/route.:ext(json|xml)+',
-    [{ name: 'ext', delimiter: '.', optional: false, repeat: true, offset: 7, length: 15 }],
+    [{ name: 'ext', delimiter: '.', optional: false, repeat: true }],
     '/route.html',
     null
   ],
@@ -305,49 +292,49 @@ var TESTS = [
    */
   [
     '/:test*',
-    [{ name: 'test', delimiter: '/', optional: true, repeat: true, offset: 1, length: 6 }],
+    [{ name: 'test', delimiter: '/', optional: true, repeat: true }],
     '/',
     ['/', undefined]
   ],
   [
     '/:test*',
-    [{ name: 'test', delimiter: '/', optional: true, repeat: true, offset: 1, length: 6 }],
+    [{ name: 'test', delimiter: '/', optional: true, repeat: true }],
     '//',
     null
   ],
   [
     '/:test*',
-    [{ name: 'test', delimiter: '/', optional: true, repeat: true, offset: 1, length: 6 }],
+    [{ name: 'test', delimiter: '/', optional: true, repeat: true }],
     '/route',
     ['/route', 'route']
   ],
   [
     '/:test*',
-    [{ name: 'test', delimiter: '/', optional: true, repeat: true, offset: 1, length: 6 }],
+    [{ name: 'test', delimiter: '/', optional: true, repeat: true }],
     '/some/basic/route',
     ['/some/basic/route', 'some/basic/route']
   ],
   [
     '/route.:ext([a-z]+)*',
-    [{ name: 'ext', delimiter: '.', optional: true, repeat: true, offset: 7, length: 13 }],
+    [{ name: 'ext', delimiter: '.', optional: true, repeat: true }],
     '/route',
     ['/route', undefined]
   ],
   [
     '/route.:ext([a-z]+)*',
-    [{ name: 'ext', delimiter: '.', optional: true, repeat: true, offset: 7, length: 13 }],
+    [{ name: 'ext', delimiter: '.', optional: true, repeat: true }],
     '/route.json',
     ['/route.json', 'json']
   ],
   [
     '/route.:ext([a-z]+)*',
-    [{ name: 'ext', delimiter: '.', optional: true, repeat: true, offset: 7, length: 13 }],
+    [{ name: 'ext', delimiter: '.', optional: true, repeat: true }],
     '/route.xml.json',
     ['/route.xml.json', 'xml.json']
   ],
   [
     '/route.:ext([a-z]+)*',
-    [{ name: 'ext', delimiter: '.', optional: true, repeat: true, offset: 7, length: 13 }],
+    [{ name: 'ext', delimiter: '.', optional: true, repeat: true }],
     '/route.123',
     null
   ],
@@ -355,56 +342,56 @@ var TESTS = [
   // Custom named parameters.
   [
     '/:test(\\d+)',
-    [{ name: 'test', delimiter: '/', optional: false, repeat: false, offset: 1, length: 10 }],
+    [{ name: 'test', delimiter: '/', optional: false, repeat: false }],
     '/123',
     ['/123', '123']
   ],
   [
     '/:test(\\d+)',
-    [{ name: 'test', delimiter: '/', optional: false, repeat: false, offset: 1, length: 10 }],
+    [{ name: 'test', delimiter: '/', optional: false, repeat: false }],
     '/abc',
     null
   ],
   [
     '/:test(\\d+)',
-    [{ name: 'test', delimiter: '/', optional: false, repeat: false, offset: 1, length: 10 }],
+    [{ name: 'test', delimiter: '/', optional: false, repeat: false }],
     '/123/abc',
     null
   ],
   [
     '/:test(\\d+)',
-    [{ name: 'test', delimiter: '/', optional: false, repeat: false, offset: 1, length: 10 }],
+    [{ name: 'test', delimiter: '/', optional: false, repeat: false }],
     '/123/abc',
     ['/123', '123'],
     { end: false }
   ],
   [
     '/:test(.*)',
-    [{ name: 'test', delimiter: '/', optional: false, repeat: false, offset: 1, length: 9 }],
+    [{ name: 'test', delimiter: '/', optional: false, repeat: false }],
     '/anything/goes/here',
     ['/anything/goes/here', 'anything/goes/here']
   ],
   [
     '/:route([a-z]+)',
-    [{ name: 'route', delimiter: '/', optional: false, repeat: false, offset: 1, length: 14 }],
+    [{ name: 'route', delimiter: '/', optional: false, repeat: false }],
     '/abcde',
     ['/abcde', 'abcde']
   ],
   [
     '/:route([a-z]+)',
-    [{ name: 'route', delimiter: '/', optional: false, repeat: false, offset: 1, length: 14 }],
+    [{ name: 'route', delimiter: '/', optional: false, repeat: false }],
     '/12345',
     null
   ],
   [
     '/:route(this|that)',
-    [{ name: 'route', delimiter: '/', optional: false, repeat: false, offset: 1, length: 17 }],
+    [{ name: 'route', delimiter: '/', optional: false, repeat: false }],
     '/this',
     ['/this', 'this']
   ],
   [
     '/:route(this|that)',
-    [{ name: 'route', delimiter: '/', optional: false, repeat: false, offset: 1, length: 17 }],
+    [{ name: 'route', delimiter: '/', optional: false, repeat: false }],
     '/that',
     ['/that', 'that']
   ],
@@ -420,35 +407,41 @@ var TESTS = [
   ],
   [
     ':test',
-    [{ name: 'test', delimiter: '/', optional: false, repeat: false, offset: 0, length: 5 }],
+    [{ name: 'test', delimiter: '/', optional: false, repeat: false }],
     'route',
     ['route', 'route']
   ],
   [
     ':test',
-    [{ name: 'test', delimiter: '/', optional: false, repeat: false, offset: 0, length: 5 }],
+    [{ name: 'test', delimiter: '/', optional: false, repeat: false }],
     '/route',
     null
   ],
   [
     ':test',
-    [{ name: 'test', delimiter: '/', optional: false, repeat: false, offset: 0, length: 5 }],
+    [{ name: 'test', delimiter: '/', optional: false, repeat: false }],
     'route/',
     ['route/', 'route']
   ],
   [
     ':test',
-    [{ name: 'test', delimiter: '/', optional: false, repeat: false, offset: 0, length: 5 }],
+    [{ name: 'test', delimiter: '/', optional: false, repeat: false }],
     'route/',
     null,
     { strict: true }
   ],
   [
     ':test',
-    [{ name: 'test', delimiter: '/', optional: false, repeat: false, offset: 0, length: 5 }],
+    [{ name: 'test', delimiter: '/', optional: false, repeat: false }],
     'route/',
     ['route/', 'route'],
     { end: false }
+  ],
+  [
+    ':test?',
+    [{ name: 'test', delimiter: '/', optional: true, repeat: false }],
+    '',
+    ['', undefined]
   ],
 
   /**
@@ -468,26 +461,26 @@ var TESTS = [
   ],
   [
     '/:test.json',
-    [{ name: 'test', delimiter: '/', optional: false, repeat: false, offset: 1, length: 5 }],
+    [{ name: 'test', delimiter: '/', optional: false, repeat: false }],
     '/route.json',
     ['/route.json', 'route']
   ],
   [
     '/:test.json',
-    [{ name: 'test', delimiter: '/', optional: false, repeat: false, offset: 1, length: 5 }],
+    [{ name: 'test', delimiter: '/', optional: false, repeat: false }],
     '/route.json.json',
     ['/route.json.json', 'route.json']
   ],
   [
     '/:test.json',
-    [{ name: 'test', delimiter: '/', optional: false, repeat: false, offset: 1, length: 5 }],
+    [{ name: 'test', delimiter: '/', optional: false, repeat: false }],
     '/route.json',
     ['/route.json', 'route'],
     { end: false }
   ],
   [
     '/:test.json',
-    [{ name: 'test', delimiter: '/', optional: false, repeat: false, offset: 1, length: 5 }],
+    [{ name: 'test', delimiter: '/', optional: false, repeat: false }],
     '/route.json.json',
     ['/route.json.json', 'route.json'],
     { end: false }
@@ -498,21 +491,21 @@ var TESTS = [
    */
   [
     '/test.:format',
-    [{ name: 'format', delimiter: '.', optional: false, repeat: false, offset: 6, length: 7 }],
+    [{ name: 'format', delimiter: '.', optional: false, repeat: false }],
     '/test.html',
     ['/test.html', 'html']
   ],
   [
     '/test.:format',
-    [{ name: 'format', delimiter: '.', optional: false, repeat: false, offset: 6, length: 7 }],
+    [{ name: 'format', delimiter: '.', optional: false, repeat: false }],
     '/test.hbs.html',
     null
   ],
   [
     '/test.:format.:format',
     [
-      { name: 'format', delimiter: '.', optional: false, repeat: false, offset: 6, length: 7 },
-      { name: 'format', delimiter: '.', optional: false, repeat: false, offset: 14, length: 7 }
+      { name: 'format', delimiter: '.', optional: false, repeat: false },
+      { name: 'format', delimiter: '.', optional: false, repeat: false }
     ],
     '/test.hbs.html',
     ['/test.hbs.html', 'hbs', 'html']
@@ -520,21 +513,21 @@ var TESTS = [
   [
     '/test.:format+',
     [
-      { name: 'format', delimiter: '.', optional: false, repeat: true, offset: 6, length: 8 }
+      { name: 'format', delimiter: '.', optional: false, repeat: true }
     ],
     '/test.hbs.html',
     ['/test.hbs.html', 'hbs.html']
   ],
   [
     '/test.:format',
-    [{ name: 'format', delimiter: '.', optional: false, repeat: false, offset: 6, length: 7 }],
+    [{ name: 'format', delimiter: '.', optional: false, repeat: false }],
     '/test.hbs.html',
     null,
     { end: false }
   ],
   [
     '/test.:format.',
-    [{ name: 'format', delimiter: '.', optional: false, repeat: false, offset: 6, length: 7 }],
+    [{ name: 'format', delimiter: '.', optional: false, repeat: false }],
     '/test.hbs.html',
     null,
     { end: false }
@@ -546,8 +539,8 @@ var TESTS = [
   [
     '/:test.:format',
     [
-      { name: 'test', delimiter: '/', optional: false, repeat: false, offset: 1, length: 5 },
-      { name: 'format', delimiter: '.', optional: false, repeat: false, offset: 7, length: 7 }
+      { name: 'test', delimiter: '/', optional: false, repeat: false },
+      { name: 'format', delimiter: '.', optional: false, repeat: false }
     ],
     '/route.html',
     ['/route.html', 'route', 'html']
@@ -555,8 +548,8 @@ var TESTS = [
   [
     '/:test.:format',
     [
-      { name: 'test', delimiter: '/', optional: false, repeat: false, offset: 1, length: 5 },
-      { name: 'format', delimiter: '.', optional: false, repeat: false, offset: 7, length: 7 }
+      { name: 'test', delimiter: '/', optional: false, repeat: false },
+      { name: 'format', delimiter: '.', optional: false, repeat: false }
     ],
     '/route',
     null
@@ -564,8 +557,8 @@ var TESTS = [
   [
     '/:test.:format',
     [
-      { name: 'test', delimiter: '/', optional: false, repeat: false, offset: 1, length: 5 },
-      { name: 'format', delimiter: '.', optional: false, repeat: false, offset: 7, length: 7 }
+      { name: 'test', delimiter: '/', optional: false, repeat: false },
+      { name: 'format', delimiter: '.', optional: false, repeat: false }
     ],
     '/route',
     null
@@ -573,8 +566,8 @@ var TESTS = [
   [
     '/:test.:format?',
     [
-      { name: 'test', delimiter: '/', optional: false, repeat: false, offset: 1, length: 5 },
-      { name: 'format', delimiter: '.', optional: true, repeat: false, offset: 7, length: 8 }
+      { name: 'test', delimiter: '/', optional: false, repeat: false },
+      { name: 'format', delimiter: '.', optional: true, repeat: false }
     ],
     '/route',
     ['/route', 'route', undefined]
@@ -582,8 +575,8 @@ var TESTS = [
   [
     '/:test.:format?',
     [
-      { name: 'test', delimiter: '/', optional: false, repeat: false, offset: 1, length: 5 },
-      { name: 'format', delimiter: '.', optional: true, repeat: false, offset: 7, length: 8 }
+      { name: 'test', delimiter: '/', optional: false, repeat: false },
+      { name: 'format', delimiter: '.', optional: true, repeat: false }
     ],
     '/route.json',
     ['/route.json', 'route', 'json']
@@ -591,8 +584,8 @@ var TESTS = [
   [
     '/:test.:format?',
     [
-      { name: 'test', delimiter: '/', optional: false, repeat: false, offset: 1, length: 5 },
-      { name: 'format', delimiter: '.', optional: true, repeat: false, offset: 7, length: 8 }
+      { name: 'test', delimiter: '/', optional: false, repeat: false },
+      { name: 'format', delimiter: '.', optional: true, repeat: false }
     ],
     '/route',
     ['/route', 'route', undefined],
@@ -601,8 +594,8 @@ var TESTS = [
   [
     '/:test.:format?',
     [
-      { name: 'test', delimiter: '/', optional: false, repeat: false, offset: 1, length: 5 },
-      { name: 'format', delimiter: '.', optional: true, repeat: false, offset: 7, length: 8 }
+      { name: 'test', delimiter: '/', optional: false, repeat: false },
+      { name: 'format', delimiter: '.', optional: true, repeat: false }
     ],
     '/route.json',
     ['/route.json', 'route', 'json'],
@@ -611,8 +604,8 @@ var TESTS = [
   [
     '/:test.:format?',
     [
-      { name: 'test', delimiter: '/', optional: false, repeat: false, offset: 1, length: 5 },
-      { name: 'format', delimiter: '.', optional: true, repeat: false, offset: 7, length: 8 }
+      { name: 'test', delimiter: '/', optional: false, repeat: false },
+      { name: 'format', delimiter: '.', optional: true, repeat: false }
     ],
     '/route.json.html',
     ['/route.json.html', 'route.json', 'html'],
@@ -620,14 +613,14 @@ var TESTS = [
   ],
   [
     '/test.:format(.*)z',
-    [{ name: 'format', delimiter: '.', optional: false, repeat: false, offset: 6, length: 11 }],
+    [{ name: 'format', delimiter: '.', optional: false, repeat: false }],
     '/test.abc',
     null,
     { end: false }
   ],
   [
     '/test.:format(.*)z',
-    [{ name: 'format', delimiter: '.', optional: false, repeat: false, offset: 6, length: 11 }],
+    [{ name: 'format', delimiter: '.', optional: false, repeat: false }],
     '/test.abcz',
     ['/test.abcz', 'abc'],
     { end: false }
@@ -638,57 +631,57 @@ var TESTS = [
    */
   [
     '/(\\d+)',
-    [{ name: '0', delimiter: '/', optional: false, repeat: false, offset: 1, length: 5 }],
+    [{ name: 0, delimiter: '/', optional: false, repeat: false }],
     '/123',
     ['/123', '123']
   ],
   [
     '/(\\d+)',
-    [{ name: '0', delimiter: '/', optional: false, repeat: false, offset: 1, length: 5 }],
+    [{ name: 0, delimiter: '/', optional: false, repeat: false }],
     '/abc',
     null
   ],
   [
     '/(\\d+)',
-    [{ name: '0', delimiter: '/', optional: false, repeat: false, offset: 1, length: 5 }],
+    [{ name: 0, delimiter: '/', optional: false, repeat: false }],
     '/123/abc',
     null
   ],
   [
     '/(\\d+)',
-    [{ name: '0', delimiter: '/', optional: false, repeat: false, offset: 1, length: 5 }],
+    [{ name: 0, delimiter: '/', optional: false, repeat: false }],
     '/123/abc',
     ['/123', '123'],
     { end: false }
   ],
   [
     '/(\\d+)',
-    [{ name: '0', delimiter: '/', optional: false, repeat: false, offset: 1, length: 5 }],
+    [{ name: 0, delimiter: '/', optional: false, repeat: false }],
     '/abc',
     null,
     { end: false }
   ],
   [
     '/(\\d+)?',
-    [{ name: '0', delimiter: '/', optional: true, repeat: false, offset: 1, length: 6 }],
+    [{ name: 0, delimiter: '/', optional: true, repeat: false }],
     '/',
     ['/', undefined]
   ],
   [
     '/(\\d+)?',
-    [{ name: '0', delimiter: '/', optional: true, repeat: false, offset: 1, length: 6 }],
+    [{ name: 0, delimiter: '/', optional: true, repeat: false }],
     '/123',
     ['/123', '123']
   ],
   [
     '/(.*)',
-    [{ name: '0', delimiter: '/', optional: false, repeat: false, offset: 1, length: 4 }],
+    [{ name: 0, delimiter: '/', optional: false, repeat: false }],
     '/route',
     ['/route', 'route']
   ],
   [
     '/(.*)',
-    [{ name: '0', delimiter: '/', optional: false, repeat: false, offset: 1, length: 4 }],
+    [{ name: 0, delimiter: '/', optional: false, repeat: false }],
     '/route/nested',
     ['/route/nested', 'route/nested']
   ],
@@ -704,13 +697,13 @@ var TESTS = [
   ],
   [
     /(.*)/,
-    [{ name: '0', delimiter: null, optional: false, repeat: false }],
+    [{ name: 0, delimiter: null, optional: false, repeat: false }],
     '/match/anything',
     ['/match/anything', '/match/anything']
   ],
   [
     /\/(\d+)/,
-    [{ name: '0', delimiter: null, optional: false, repeat: false }],
+    [{ name: 0, delimiter: null, optional: false, repeat: false }],
     '/123',
     ['/123', '123']
   ],
@@ -720,15 +713,15 @@ var TESTS = [
    */
   [
     ['/test', /\/(\d+)/],
-    [{ name: '0', delimiter: null, optional: false, repeat: false }],
+    [{ name: 0, delimiter: null, optional: false, repeat: false }],
     '/test',
     ['/test', undefined]
   ],
   [
     ['/:test(\\d+)', /(.*)/],
     [
-      { name: 'test', delimiter: '/', optional: false, repeat: false, offset: 1, length: 10 },
-      { name: '0', delimiter: null, optional: false, repeat: false }
+      { name: 'test', delimiter: '/', optional: false, repeat: false },
+      { name: 0, delimiter: null, optional: false, repeat: false }
     ],
     '/123',
     ['/123', '123', undefined]
@@ -736,8 +729,8 @@ var TESTS = [
   [
     ['/:test(\\d+)', /(.*)/],
     [
-      { name: 'test', delimiter: '/', optional: false, repeat: false, offset: 1, length: 10 },
-      { name: '0', delimiter: null, optional: false, repeat: false }
+      { name: 'test', delimiter: '/', optional: false, repeat: false },
+      { name: 0, delimiter: null, optional: false, repeat: false }
     ],
     '/abc',
     ['/abc', undefined, '/abc']
@@ -749,8 +742,8 @@ var TESTS = [
   [
     ['/:test', '/route/:test'],
     [
-      { name: 'test', delimiter: '/', optional: false, repeat: false, offset: 1, length: 5 },
-      { name: 'test', delimiter: '/', optional: false, repeat: false, offset: 7, length: 5 }
+      { name: 'test', delimiter: '/', optional: false, repeat: false },
+      { name: 'test', delimiter: '/', optional: false, repeat: false }
     ],
     '/test',
     ['/test', 'test', undefined]
@@ -758,8 +751,8 @@ var TESTS = [
   [
     ['/:test', '/route/:test'],
     [
-      { name: 'test', delimiter: '/', optional: false, repeat: false, offset: 1, length: 5 },
-      { name: 'test', delimiter: '/', optional: false, repeat: false, offset: 7, length: 5 }
+      { name: 'test', delimiter: '/', optional: false, repeat: false },
+      { name: 'test', delimiter: '/', optional: false, repeat: false }
     ],
     '/route/test',
     ['/route/test', undefined, 'test']
@@ -767,8 +760,8 @@ var TESTS = [
   [
     [/^\/([^\/]+)$/, /^\/route\/([^\/]+)$/],
     [
-      { name: '0', delimiter: null, optional: false, repeat: false },
-      { name: '0', delimiter: null, optional: false, repeat: false }
+      { name: 0, delimiter: null, optional: false, repeat: false },
+      { name: 0, delimiter: null, optional: false, repeat: false }
     ],
     '/test',
     ['/test', 'test', undefined]
@@ -776,8 +769,8 @@ var TESTS = [
   [
     [/^\/([^\/]+)$/, /^\/route\/([^\/]+)$/],
     [
-      { name: '0', delimiter: null, optional: false, repeat: false },
-      { name: '0', delimiter: null, optional: false, repeat: false }
+      { name: 0, delimiter: null, optional: false, repeat: false },
+      { name: 0, delimiter: null, optional: false, repeat: false }
     ],
     '/route/test',
     ['/route/test', undefined, 'test']
@@ -821,8 +814,8 @@ var TESTS = [
   [
     '/:foo/:bar',
     [
-      { name: 'foo', delimiter: '/', optional: false, repeat: false, offset: 1, length: 4 },
-      { name: 'bar', delimiter: '/', optional: false, repeat: false, offset: 6, length: 4 }
+      { name: 'foo', delimiter: '/', optional: false, repeat: false },
+      { name: 'bar', delimiter: '/', optional: false, repeat: false }
     ],
     '/match/route',
     ['/match/route', 'match', 'route']
@@ -830,8 +823,8 @@ var TESTS = [
   [
     '/:remote([\\w-.]+)/:user([\\w-]+)',
     [
-      { name: 'remote', delimiter: '/', optional: false, repeat: false, offset: 1, length: 16 },
-      { name: 'user', delimiter: '/', optional: false, repeat: false, offset: 18, length: 13 }
+      { name: 'remote', delimiter: '/', optional: false, repeat: false },
+      { name: 'user', delimiter: '/', optional: false, repeat: false }
     ],
     '/endpoint/user',
     ['/endpoint/user', 'endpoint', 'user']
@@ -842,25 +835,38 @@ var TESTS = [
  * Dynamically generate the entire test suite.
  */
 describe('path-to-regexp', function () {
+  var TEST_PATH = '/user/:id'
+
+  var TEST_PARAM = {
+    name: 'id',
+    prefix: '/',
+    delimiter: '/',
+    optional: false,
+    repeat: false,
+    pattern: '[^\\/]+?'
+  }
+
+  describe('parse', function () {
+    it('should parse the string', function () {
+      var tokens = pathToRegexp.parse(TEST_PATH)
+
+      expect(tokens).to.deep.equal(['/user', TEST_PARAM])
+    })
+  })
+
   describe('arguments', function () {
     it('should work without second keys', function () {
-      var re = pathToRegexp('/user/:id', { end: false })
-      var params = [
-        { name: 'id', delimiter: '/', optional: false, repeat: false, offset: 6, length: 3 }
-      ]
+      var re = pathToRegexp(TEST_PATH, { end: false })
 
-      assert.deepEqual(re.keys, params)
-      assert.deepEqual(exec(re, '/user/123/show'), ['/user/123', '123'])
+      expect(re.keys).to.deep.equal([TEST_PARAM])
+      expect(exec(re, '/user/123/show')).to.deep.equal(['/user/123', '123'])
     })
 
     it('should work with keys as null', function () {
-      var re = pathToRegexp('/user/:id', null, { end: false })
-      var params = [
-        { name: 'id', delimiter: '/', optional: false, repeat: false, offset: 6, length: 3 }
-      ]
+      var re = pathToRegexp(TEST_PATH, null, { end: false })
 
-      assert.deepEqual(re.keys, params)
-      assert.deepEqual(exec(re, '/user/123/show'), ['/user/123', '123'])
+      expect(re.keys).to.deep.equal([TEST_PARAM])
+      expect(exec(re, '/user/123/show')).to.deep.equal(['/user/123', '123'])
     })
   })
 
@@ -885,16 +891,53 @@ describe('path-to-regexp', function () {
 
       // Execute the test and check each parameter is as expected.
       it(description, function () {
-        var params = []
-        var re = pathToRegexp(test[0], params, test[4])
+        var keys = []
+        var re = pathToRegexp(test[0], keys, test[4])
 
-        // Check the keys are as expected.
-        assert.equal(re.keys, params)
-        assert.deepEqual(params, test[1])
+        // Remove pattern from the keys to test (subjective).
+        var params = keys.map(function (value) {
+          return omit(['prefix', 'pattern'], value)
+        })
 
-        // Run the regexp and check the result is expected.
-        assert.deepEqual(exec(re, test[2]), test[3])
+        // Check the keys match each other and the expected output.
+        expect(re.keys).to.equal(keys)
+        expect(params).to.deep.equal(test[1])
+
+        // Run the regexp and check the result as expected.
+        expect(exec(re, test[2])).to.deep.equal(test[3])
       })
     })
   })
 })
+
+/**
+ * Execute a regular expression and return a flat array for comparison.
+ *
+ * @param  {RegExp} re
+ * @param  {String} str
+ * @return {Array}
+ */
+function exec (re, str) {
+  var match = re.exec(str)
+
+  return match && Array.prototype.slice.call(match)
+}
+
+/**
+ * Omit keys from the source object.
+ *
+ * @param  {Array}  keys
+ * @param  {Object} src
+ * @return {Object}
+ */
+function omit (keys, src) {
+  var dest = {}
+
+  Object.keys(src).forEach(function (key) {
+    if (keys.indexOf(key) === -1) {
+      dest[key] = src[key]
+    }
+  })
+
+  return dest
+}

--- a/test.js
+++ b/test.js
@@ -862,6 +862,96 @@ describe('path-to-regexp', function () {
     })
   })
 
+  describe('compile', function () {
+    it('should compile a path into a function for reversing', function () {
+      var toPath = pathToRegexp.compile(TEST_PATH)
+
+      expect(toPath({ id: 123 })).to.equal('/user/123')
+    })
+
+    it('should generate path without parameters', function () {
+      var toPath = pathToRegexp.compile('/user')
+
+      expect(toPath()).to.equal('/user')
+    })
+
+    it('should omit optional parameters', function () {
+      var toPath = pathToRegexp.compile('/a/:b?/c')
+
+      expect(toPath()).to.equal('/a/c')
+    })
+
+    it('should throw when a required param is undefined', function () {
+      var toPath = pathToRegexp.compile('/a/:b/c')
+
+      expect(function () {
+        toPath()
+      }).to.throw(TypeError, 'Expected "b" to be defined')
+    })
+
+    it('should encode path parameters', function () {
+      var toPath = pathToRegexp.compile('/:foo')
+
+      expect(toPath({ foo: 'café' })).to.equal('/caf%C3%A9')
+    })
+
+    it('should throw when it does not match the pattern', function () {
+      var toPath = pathToRegexp.compile('/:foo(\\d+)')
+
+      expect(function () {
+        toPath({ foo: 'abc' })
+      }).to.throw(TypeError, 'Expected "foo" to match "\\d+"')
+    })
+
+    it('should handle repeated values', function () {
+      var toPath = pathToRegexp.compile('/:foo+')
+
+      expect(toPath({ foo: [1, 2, 3] })).to.equal('/1/2/3')
+    })
+
+    it('should throw when expecting a repeated value', function () {
+      var toPath = pathToRegexp.compile('/:foo+')
+
+      expect(function () {
+        toPath({ foo: [] })
+      }).to.throw(TypeError, 'Expected "foo" to not be empty')
+    })
+
+    it('should throw when not expecting a repeated value', function () {
+      var toPath = pathToRegexp.compile('/:foo')
+
+      expect(function () {
+        toPath({ foo: [] })
+      }).to.throw(TypeError, 'Expected "foo" to not repeat')
+    })
+
+    it('should throw when repeated value does not match', function () {
+      var toPath = pathToRegexp.compile('/:foo(\\d+)+')
+
+      expect(function () {
+        toPath({ foo: [1, 2, 3, 'a'] })
+      }).to.throw(TypeError, 'Expected all "foo" to match "\\d+"')
+    })
+
+    it('should allow optional repeated values', function () {
+      var toPath = pathToRegexp.compile('/user/:id(\\d+)*')
+
+      expect(toPath()).to.equal('/user')
+    })
+
+    it('should allow optional repeated values to be empty arrays', function () {
+      var toPath = pathToRegexp.compile('/user/:id(\\d+)*')
+
+      expect(toPath({ id: [] })).to.equal('/user')
+    })
+
+    it('should handle optional repeated parameters', function () {
+      var toPath = pathToRegexp.compile('/a/:b*/c')
+
+      expect(toPath({ b: [1, 2, 3] })).to.equal('/a/1/2/3/c')
+    })
+  })
+
   describe('arguments', function () {
     it('should work without second keys', function () {
       var re = pathToRegexp(TEST_PATH, { end: false })

--- a/test.js
+++ b/test.js
@@ -828,6 +828,14 @@ var TESTS = [
     ],
     '/endpoint/user',
     ['/endpoint/user', 'endpoint', 'user']
+  ],
+  [
+    '/:foo\\?',
+    [
+      { name: 'foo', delimiter: '/', optional: false, repeat: false }
+    ],
+    '/route?',
+    ['/route?', 'route']
   ]
 ]
 


### PR DESCRIPTION
With this PR we expose the `parse` method to consumers. This can be used to get the segments of the path, as well as the sanitised strings (currently we're just removing escape characters from things the user may have escaped from us). From this, it's trivial to construct a path builder and the `toRegexp` functionality will use the parser from now on. 