### PR TITLE
Work In Progress: added sauce labs test support

### DIFF
--- a/.min-wd
+++ b/.min-wd
@@ -1,0 +1,13 @@
+{
+  "sauceLabs": true,
+  "BUILD_VAR": "TRAVIS_BUILD_NUMBER",
+  "url": "http://wesleytodd.com/webdriver.html",
+  "browsers": [{
+    "name": "chrome"
+  }, {
+    "name": "firefox"
+  }, {
+    "name": "internet explorer",
+	"version": "10"
+  }]
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,15 @@ node_js:
   - "0.12"
   - "4.0"
   - "4.1"
+  - "5.9"
 
 after_script: "npm install coveralls@2 && cat ./coverage/lcov.info | coveralls"
+
+env:
+  global:
+    - SAUCE_USERNAME=""
+    - secure: ""
+
+script:
+  - 'npm test'
+  - 'if [ "x$TRAVIS_NODE_VERSION" = "x5.9" ]; then npm run test-browser; fi'

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "scripts": {
     "lint": "standard",
     "test-spec": "mocha -R spec --bail",
+    "test-browser": "mochify --wd test.js",
     "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- -R spec",
     "test": "npm run lint && npm run test-cov"
   },
@@ -32,6 +33,7 @@
     "chai": "^2.3.0",
     "istanbul": "~0.3.0",
     "mocha": "~2.2.4",
+    "mochify": "^2.17.0",
     "pre-commit": "~1.0.5",
     "standard": "~3.7.3"
   },


### PR DESCRIPTION
This is the initial work for running these test in browsers on Sauce Labs.  I ran them using my credentials used for another project and it all passed in Chrome, FF and IE10.  We just need a few things:
- [ ] Sauce Labs account for the project
- [ ] Add encrypted key to the `.travis.yml`
- [ ] Add a badge to the `README.md` once we have the account setup

Here are [instructions on encrypting the key](https://docs.travis-ci.com/user/encryption-keys/).  My assumption would be that @dougwilson would want to have all the accounts and place the ownership under the Node Foundation, but that is up to the @pillarjs/express-tc I guess.  Let me know when you have the encrypted keys, or just take over this PR.

Here is what my working `.travis.yml` looks like for reference: https://github.com/wesleytodd/nighthawk/blob/master/.travis.yml
