### PR TITLE
leave more characters unescaped for segments

### DIFF
--- a/index.js
+++ b/index.js
@@ -112,6 +112,18 @@ function compile (str) {
 }
 
 /**
+ * Encode characters for segment that could cause trouble for parsing.
+ *
+ * @param  {string}
+ * @return {string}
+ */
+function encodeSegment (str) {
+  return encodeURI(str).replace(/[/?#'"]/g, function (c) {
+    return '%' + c.charCodeAt(0).toString(16).toUpperCase()
+  })
+}
+
+/**
  * Expose a method for transforming tokens into the path function.
  */
 function tokensToFunction (tokens) {
@@ -163,7 +175,7 @@ function tokensToFunction (tokens) {
         }
 
         for (var j = 0; j < value.length; j++) {
-          segment = encodeURIComponent(value[j])
+          segment = encodeSegment(value[j])
 
           if (!matches[i].test(segment)) {
             throw new TypeError('Expected all "' + token.name + '" to match "' + token.pattern + '", but received "' + segment + '"')
@@ -175,7 +187,7 @@ function tokensToFunction (tokens) {
         continue
       }
 
-      segment = encodeURIComponent(value)
+      segment = encodeSegment(value)
 
       if (!matches[i].test(segment)) {
         throw new TypeError('Expected "' + token.name + '" to match "' + token.pattern + '", but received "' + segment + '"')

--- a/test.js
+++ b/test.js
@@ -385,11 +385,15 @@ var TESTS = [
       ['/another', ['/another', 'another']],
       ['/something/else', null],
       ['/route.json', ['/route.json', 'route.json']],
-      ['/something%2Felse', ['/something%2Felse', 'something%2Felse']]
+      ['/something%2Felse', ['/something%2Felse', 'something%2Felse']],
+      ['/something%2Felse%2Fmore', ['/something%2Felse%2Fmore', 'something%2Felse%2Fmore']],
+      ['/;,:@&=+$-_.!~*()', ['/;,:@&=+$-_.!~*()', ';,:@&=+$-_.!~*()']]
     ],
     [
       [{ test: 'route' }, '/route'],
-      [{ test: 'something/else' }, '/something%2Felse']
+      [{ test: 'something/else' }, '/something%2Felse'],
+      [{ test: 'something/else/more' }, '/something%2Felse%2Fmore'],
+      [{ test: ';,:@&=+$-_.!~*()' }, '/;,:@&=+$-_.!~*()']
     ]
   ],
   [
@@ -786,12 +790,15 @@ var TESTS = [
       }
     ],
     [
-      ['/anything/goes/here', ['/anything/goes/here', 'anything/goes/here']]
+      ['/anything/goes/here', ['/anything/goes/here', 'anything/goes/here']],
+      ['/;,:@&=/+$-_.!/~*()', ['/;,:@&=/+$-_.!/~*()', ';,:@&=/+$-_.!/~*()']]
     ],
     [
       [{ test: '' }, '/'],
       [{ test: 'abc' }, '/abc'],
-      [{ test: 'abc/123' }, '/abc%2F123']
+      [{ test: 'abc/123' }, '/abc%2F123'],
+      [{ test: 'abc/123/456' }, '/abc%2F123%2F456'],
+      [{ test: ';,:@&=/+$-_.!/~*()' }, '/;,:@&=%2F+$-_.!%2F~*()']
     ]
   ],
   [


### PR DESCRIPTION
I am using `path-to-regexp` in [`url-mapper`](https://github.com/cerebral/url-mapper) which allows to map almost any json compatible object to url with path and query. The key feature is [preserving type](https://github.com/cerebral/cerebral-module-router#preserving-payload-type) of values, so `assert.equal(parse(stringify(object)), object)`.
Routes defined with `path-to-regexp` format, keys of object defined in route stringified with `path-to-regexp`, rest of keys goes to query part with help of [urlon](https://github.com/vjeux/URLON).

[Tonic demo](https://tonicdev.com/npm/url-mapper).

`url-mapper` allows map only simple values (strings, numbers and booleans) to path parameters. To allow preserving type for numbers and booleans they are prepended with colon character. Here is where issue starts: `path-to-regexp` encodes segments with `encodeURIComponent` function and converts colons to '%3A', which makes url to look more cryptic in path part.

[Tonic demo](https://tonicdev.com/guria/5715e701d286771100079fb2)

This PR tries to address this problem by treat `;,:@&=+$-_.!~*()` characters as safe to be part of segment. According to [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURIComponent):
> To avoid unexpected requests to the server, you should call encodeURIComponent on any user-entered parameters that will be passed as part of a URI.

It means there is no need to use `encodeURIComponent` to encode segment part, because it's too strict. I have introduced extended version on `encodeURI` with escaping `/?#'"` characters and added some tests as well.

I am suppose, that it should be treated as `major` change because it potentially could break matching and expectations.