### PR TITLE
Fix inconsistency between "exec" and "compile" when parameters with modifiers contain slashes

### DIFF
--- a/index.js
+++ b/index.js
@@ -177,6 +177,10 @@ function tokensToFunction (tokens) {
         }
       }
 
+      if (typeof value === 'string' && token.repeat) {
+        value = value.match(new RegExp('([^' + escapeString(token.delimiter) + ']+)', 'g'))
+      }
+
       if (isarray(value)) {
         if (!token.repeat) {
           throw new TypeError('Expected "' + token.name + '" to not repeat, but received `' + JSON.stringify(value) + '`')

--- a/test.ts
+++ b/test.ts
@@ -739,6 +739,7 @@ var TESTS: Test[] = [
     [
       [{}, ''],
       [{ test: 'foobar' }, '/foobar'],
+      [{ test: 'foo/bar' }, '/foo/bar'],
       [{ test: ['foo', 'bar'] }, '/foo/bar']
     ]
   ],
@@ -2010,7 +2011,7 @@ var TESTS: Test[] = [
     ],
     [
       [{ foo: 'foo' }, '/foobaz'],
-      [{ foo: 'foo/bar' }, '/foo%2Fbarbaz'],
+      [{ foo: 'foo/bar' }, '/foo/barbaz'],
       [{ foo: ['foo', 'bar'] }, '/foo/barbaz']
     ]
   ],


### PR DESCRIPTION
Reading through the tests I found usecases where the behavior of "exec" and "compile" seems to be inconsistent : 

```js
var re = pathToRegexp('/:test*');
re.exec('/some/basic/route');
// ['/some/basic/route', 'some/basic/route']
var toPath = pathToRegexp.compile('/:test*')
toPath({ test: 'some/basic/route' });
// /some%2Fbasic%2Froute
toPath({ test: ['some', 'basic', 'route'] });
// /some/basic/route
```

From what I understand from the docs these usecases should look like this :

```js
var re = pathToRegexp('/:test*');
re.exec('/some/basic/route');
// ['/some/basic/route', 'some/basic/route']
var toPath = pathToRegexp.compile('/:test*')
toPath({ test: 'some/basic/route' });
// /some/basic/route
toPath({ test: ['some', 'basic', 'route'] });
// /some/basic/route
```

What do you think ?