### PR TITLE
Remove isarray dependency

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -221,6 +221,14 @@ Path-To-RegExp exposes the two functions used internally that accept an array of
 * `pattern` The RegExp used to match this token (`string`)
 * `asterisk` Indicates the token is an `*` match (`boolean`)
 
+## Browser Support
+
+Path-To-RegExp supports all popular browsers, including Internet Explorer 9 and above.
+
+For compatibility with older browsers that don't support ES5 methods you may need to include
+[`Array.isArray()` polyfill](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/isArray#Polyfill)
+before any other code.
+
 ## Compatibility with Express <= 4.x
 
 Path-To-RegExp breaks compatibility with Express <= `4.x`:

--- a/index.js
+++ b/index.js
@@ -1,5 +1,3 @@
-var isarray = require('isarray')
-
 /**
  * Expose `pathToRegexp`.
  */
@@ -180,7 +178,7 @@ function tokensToFunction (tokens) {
         }
       }
 
-      if (isarray(value)) {
+      if (Array.isArray(value)) {
         if (!token.repeat) {
           throw new TypeError('Expected "' + token.name + '" to not repeat, but received `' + JSON.stringify(value) + '`')
         }
@@ -331,7 +329,7 @@ function stringToRegexp (path, keys, options) {
  * @return {!RegExp}
  */
 function tokensToRegExp (tokens, keys, options) {
-  if (!isarray(keys)) {
+  if (!Array.isArray(keys)) {
     options = /** @type {!Object} */ (keys || options)
     keys = []
   }
@@ -407,7 +405,7 @@ function tokensToRegExp (tokens, keys, options) {
  * @return {!RegExp}
  */
 function pathToRegexp (path, keys, options) {
-  if (!isarray(keys)) {
+  if (!Array.isArray(keys)) {
     options = /** @type {!Object} */ (keys || options)
     keys = []
   }
@@ -418,7 +416,7 @@ function pathToRegexp (path, keys, options) {
     return regexpToRegexp(path, /** @type {!Array} */ (keys))
   }
 
-  if (isarray(path)) {
+  if (Array.isArray(path)) {
     return arrayToRegexp(/** @type {!Array} */ (path), /** @type {!Array} */ (keys), options)
   }
 

--- a/package.json
+++ b/package.json
@@ -40,8 +40,5 @@
     "ts-node": "^0.5.5",
     "typescript": "^1.8.7",
     "typings": "^1.0.4"
-  },
-  "dependencies": {
-    "isarray": "1.0.0"
   }
 }


### PR DESCRIPTION
I think it is better to don't include shims and polyfills to the library code and only add notes about used ES5/ES6/ES7 features to the readme file. It allows to avoid code duplication and decrease final bundle size for most of projects.

`Array.isArray()` compatibility:

[Desktop browsers](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/isArray#Browser_compatibility)

Feature | Chrome | Firefox (Gecko) | Internet Explorer | Opera | Safari
-- | -- | -- | -- | -- | --
Basic support | 5 | 4.0 (2.0) | 9 | 10.5 | 5

[Mobile browsers](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/isArray#Browser_compatibility)

Feature | Android | Chrome for Android | Firefox Mobile (Gecko) | IE Mobile | Opera Mobile | Safari Mobile
-- | -- | -- | -- | -- | -- | --
Basic support | (Yes) | (Yes) | 4.0 (2.0) | (Yes) | (Yes) | (Yes)

[Node.js](http://node.green/#ES2015-subclassing-Array-is-subclassable-Array-isArray-support)

7.9.0 | 7.5.0 | 6.10.2 | 6.4.0 | 5.12.0 | 4.8.2 | 0.12.18 | 0.10.48
-- | -- | -- | -- | -- | -- | -- | --
Yes | Yes | Yes | Yes | Yes | Yes | Error | Error

This is a **BREAKING CHANGE** which requires increasing of the major version by [semver](http://semver.org/).
Maybe it is a good time to release `2.0`? :)

Refs: #88, #73