### PR TITLE
PATH_REGEXP issue with non-word-characters in parameters

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ var PATH_REGEXP = new RegExp([
   // "/:test(\\d+)?" => ["/", "test", "\d+", undefined, "?", undefined]
   // "/route(\\d+)"  => [undefined, undefined, undefined, "\d+", undefined, undefined]
   // "/*"            => ["/", undefined, undefined, undefined, undefined, "*"]
-  '([\\/.])?(?:(?:\\:(\\w+)(?:\\(((?:\\\\.|[^\\\\()])+)\\))?|\\(((?:\\\\.|[^\\\\()])+)\\))([+*?])?|(\\*))'
+  '([\\/.])?(?:(?:\\:([^\\/\\?\\#]+)(?:\\(((?:\\\\.|[^\\\\()])+)\\))?|\\(((?:\\\\.|[^\\\\()])+)\\))([+*?])?|(\\*))'
 ].join('|'), 'g')
 
 /**


### PR DESCRIPTION
If a path-parameter contains a non-word-character, than the parameter-name is not correct parsed. 

For example: 
A the path ´´http://.../list-resource/{resource-id}´´(open api spec) ´´.../list-resource/:resource-id´´ will evaluate ´´resource´´ as paramater-name ("-" is valid part of an uri).

The new RegExp recognize only the uri-part-separators (/ ? #) as segment-delimiters. 