### PR TITLE
PATH_REGEXP issue with "-" in parameter names

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ var PATH_REGEXP = new RegExp([
   // "/:test(\\d+)?" => ["/", "test", "\d+", undefined, "?", undefined]
   // "/route(\\d+)"  => [undefined, undefined, undefined, "\d+", undefined, undefined]
   // "/*"            => ["/", undefined, undefined, undefined, undefined, "*"]
-  '([\\/.])?(?:(?:\\:(\\w+)(?:\\(((?:\\\\.|[^\\\\()])+)\\))?|\\(((?:\\\\.|[^\\\\()])+)\\))([+*?])?|(\\*))'
+  '([\\/.])?(?:(?:\\:([^\\/\\?\\#]+)(?:\\(((?:\\\\.|[^\\\\()])+)\\))?|\\(((?:\\\\.|[^\\\\()])+)\\))([+*?])?|(\\*))'
 ].join('|'), 'g')
 
 /**

--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ var PATH_REGEXP = new RegExp([
   // "/:test(\\d+)?" => ["/", "test", "\d+", undefined, "?", undefined]
   // "/route(\\d+)"  => [undefined, undefined, undefined, "\d+", undefined, undefined]
   // "/*"            => ["/", undefined, undefined, undefined, undefined, "*"]
-  '([\\/.])?(?:(?:\\:([^\\/\\?\\#]+)(?:\\(((?:\\\\.|[^\\\\()])+)\\))?|\\(((?:\\\\.|[^\\\\()])+)\\))([+*?])?|(\\*))'
+  '([\\/.])?(?:(?:\\:([a-zA-Z0-9\\-\\_]+)(?:\\(((?:\\\\.|[^\\\\()])+)\\))?|\\(((?:\\\\.|[^\\\\()])+)\\))([+*?])?|(\\*))'
 ].join('|'), 'g')
 
 /**


### PR DESCRIPTION
If a path-parameter contains a "-", than the parameter-name is not correct parsed.

For example:
A the path ´´http://.../list-resource/{resource-id}´´(open api spec) ´´.../list-resource/:resource-id´´ will evaluate ´´resource´´ as paramater-name ("-" is valid part of an uri).

A "-" was added to the RegExp.

Tests done.