### PR TITLE
Major changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
+sudo: false
 language: node_js
 
 node_js:
-  - "0.10"
-  - "0.12"
   - "4.0"
-  - "4.1"
+  - "stable"
 
 after_script: "npm install coveralls@2 && cat ./coverage/lcov.info | coveralls"

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,12 +1,6 @@
-declare function pathToRegexp (path: pathToRegexp.Path, options?: pathToRegexp.RegExpOptions & pathToRegexp.ParseOptions): pathToRegexp.PathRegExp;
-declare function pathToRegexp (path: pathToRegexp.Path, keys?: pathToRegexp.Key[], options?: pathToRegexp.RegExpOptions & pathToRegexp.ParseOptions): pathToRegexp.PathRegExp;
+declare function pathToRegexp (path: pathToRegexp.Path, keys?: pathToRegexp.Key[], options?: pathToRegexp.RegExpOptions & pathToRegexp.ParseOptions): RegExp;
 
 declare namespace pathToRegexp {
-  export interface PathRegExp extends RegExp {
-    // An array to be populated with the keys found in the path.
-    keys: Key[];
-  }
-
   export interface RegExpOptions {
     /**
      * When `true` the route will be case sensitive. (default: `false`)
@@ -24,6 +18,10 @@ declare namespace pathToRegexp {
      * Sets the final character for non-ending optimistic matches. (default: `/`)
      */
     delimiter?: string;
+    /**
+     * List of characters that can also be "end" characters.
+     */
+    endsWith?: string | string[];
   }
 
   export interface ParseOptions {
@@ -31,6 +29,10 @@ declare namespace pathToRegexp {
      * Set the default delimiter for repeat parameters. (default: `'/'`)
      */
     delimiter?: string;
+    /**
+     * List of valid delimiter characters. (default: `'./'`)
+     */
+    delimiters?: string | string[];
   }
 
   /**
@@ -51,8 +53,7 @@ declare namespace pathToRegexp {
   /**
    * Transform an array of tokens into a matching regular expression.
    */
-  export function tokensToRegExp (tokens: Token[], options?: RegExpOptions): PathRegExp;
-  export function tokensToRegExp (tokens: Token[], keys?: Key[], options?: RegExpOptions): PathRegExp;
+  export function tokensToRegExp (tokens: Token[], keys?: Key[], options?: RegExpOptions): RegExp;
 
   export interface Key {
     name: string | number;
@@ -62,11 +63,13 @@ declare namespace pathToRegexp {
     repeat: boolean;
     pattern: string;
     partial: boolean;
-    asterisk: boolean;
   }
 
   interface PathFunctionOptions {
-    pretty?: boolean;
+    /**
+     * Function for encoding input strings for output.
+     */
+    encode?: (value: string) => string;
   }
 
   export type Token = string | Key;

--- a/index.js
+++ b/index.js
@@ -1,5 +1,3 @@
-var isarray = require('isarray')
-
 /**
  * Expose `pathToRegexp`.
  */
@@ -21,10 +19,9 @@ var PATH_REGEXP = new RegExp([
   // Match Express-style parameters and un-named parameters with a prefix
   // and optional suffixes. Matches appear as:
   //
-  // "/:test(\\d+)?" => ["/", "test", "\d+", undefined, "?", undefined]
-  // "/route(\\d+)"  => [undefined, undefined, undefined, "\d+", undefined, undefined]
-  // "/*"            => ["/", undefined, undefined, undefined, undefined, "*"]
-  '([\\/.])?(?:(?:\\:(\\w+)(?:\\(((?:\\\\.|[^\\\\()])+)\\))?|\\(((?:\\\\.|[^\\\\()])+)\\))([+*?])?|(\\*))'
+  // "/:test(\\d+)?" => ["/", "test", "\d+", undefined, "?"]
+  // "/route(\\d+)"  => [undefined, undefined, undefined, "\d+", undefined]
+  '(?:\\:(\\w+)(?:\\(((?:\\\\.|[^\\\\()])+)\\))?|\\(((?:\\\\.|[^\\\\()])+)\\))([+*?])?'
 ].join('|'), 'g')
 
 /**
@@ -39,10 +36,12 @@ function parse (str, options) {
   var key = 0
   var index = 0
   var path = ''
-  var defaultDelimiter = options && options.delimiter || '/'
+  var defaultDelimiter = (options && options.delimiter) || '/'
+  var delimiters = (options && options.delimiters) || './'
+  var pathEscaped = false
   var res
 
-  while ((res = PATH_REGEXP.exec(str)) != null) {
+  while ((res = PATH_REGEXP.exec(str)) !== null) {
     var m = res[0]
     var escaped = res[1]
     var offset = res.index
@@ -52,49 +51,53 @@ function parse (str, options) {
     // Ignore already escaped sequences.
     if (escaped) {
       path += escaped[1]
+      pathEscaped = true
       continue
     }
 
+    var prev = ''
     var next = str[index]
-    var prefix = res[2]
-    var name = res[3]
-    var capture = res[4]
-    var group = res[5]
-    var modifier = res[6]
-    var asterisk = res[7]
+    var name = res[2]
+    var capture = res[3]
+    var group = res[4]
+    var modifier = res[5]
+
+    if (!pathEscaped && path.length) {
+      var k = path.length - 1
+
+      if (delimiters.indexOf(path[k]) > -1) {
+        prev = path[k]
+        path = path.slice(0, k)
+      }
+    }
 
     // Push the current path onto the tokens.
     if (path) {
       tokens.push(path)
       path = ''
+      pathEscaped = false
     }
 
-    var partial = prefix != null && next != null && next !== prefix
+    var partial = prev !== '' && next !== undefined && next !== prev
     var repeat = modifier === '+' || modifier === '*'
     var optional = modifier === '?' || modifier === '*'
-    var delimiter = res[2] || defaultDelimiter
+    var delimiter = prev || defaultDelimiter
     var pattern = capture || group
 
     tokens.push({
       name: name || key++,
-      prefix: prefix || '',
+      prefix: prev,
       delimiter: delimiter,
       optional: optional,
       repeat: repeat,
       partial: partial,
-      asterisk: !!asterisk,
-      pattern: pattern ? escapeGroup(pattern) : (asterisk ? '.*' : '[^' + escapeString(delimiter) + ']+?')
+      pattern: pattern ? escapeGroup(pattern) : '[^' + escapeString(delimiter) + ']+?'
     })
   }
 
-  // Match any characters still remaining.
-  if (index < str.length) {
-    path += str.substr(index)
-  }
-
-  // If the path exists, push it onto the end.
-  if (path) {
-    tokens.push(path)
+  // Push any remaining characters.
+  if (path || index < str.length) {
+    tokens.push(path + str.substr(index))
   }
 
   return tokens
@@ -112,30 +115,6 @@ function compile (str, options) {
 }
 
 /**
- * Prettier encoding of URI path segments.
- *
- * @param  {string}
- * @return {string}
- */
-function encodeURIComponentPretty (str) {
-  return encodeURI(str).replace(/[\/?#]/g, function (c) {
-    return '%' + c.charCodeAt(0).toString(16).toUpperCase()
-  })
-}
-
-/**
- * Encode the asterisk parameter. Similar to `pretty`, but allows slashes.
- *
- * @param  {string}
- * @return {string}
- */
-function encodeAsterisk (str) {
-  return encodeURI(str).replace(/[?#]/g, function (c) {
-    return '%' + c.charCodeAt(0).toString(16).toUpperCase()
-  })
-}
-
-/**
  * Expose a method for transforming tokens into the path function.
  */
 function tokensToFunction (tokens) {
@@ -149,55 +128,37 @@ function tokensToFunction (tokens) {
     }
   }
 
-  return function (obj, opts) {
+  return function (data, options) {
     var path = ''
-    var data = obj || {}
-    var options = opts || {}
-    var encode = options.pretty ? encodeURIComponentPretty : encodeURIComponent
+    var encode = (options && options.encode) || encodeURIComponent
 
     for (var i = 0; i < tokens.length; i++) {
       var token = tokens[i]
 
       if (typeof token === 'string') {
         path += token
-
         continue
       }
 
-      var value = data[token.name]
+      var value = data ? data[token.name] : undefined
       var segment
 
-      if (value == null) {
-        if (token.optional) {
-          // Prepend partial segment prefixes.
-          if (token.partial) {
-            path += token.prefix
-          }
-
-          continue
-        } else {
-          throw new TypeError('Expected "' + token.name + '" to be defined')
-        }
-      }
-
-      if (isarray(value)) {
+      if (Array.isArray(value)) {
         if (!token.repeat) {
-          throw new TypeError('Expected "' + token.name + '" to not repeat, but received `' + JSON.stringify(value) + '`')
+          throw new TypeError('Expected "' + token.name + '" to not repeat, but got array')
         }
 
         if (value.length === 0) {
-          if (token.optional) {
-            continue
-          } else {
-            throw new TypeError('Expected "' + token.name + '" to not be empty')
-          }
+          if (token.optional) continue
+
+          throw new TypeError('Expected "' + token.name + '" to not be empty')
         }
 
         for (var j = 0; j < value.length; j++) {
           segment = encode(value[j])
 
           if (!matches[i].test(segment)) {
-            throw new TypeError('Expected all "' + token.name + '" to match "' + token.pattern + '", but received `' + JSON.stringify(segment) + '`')
+            throw new TypeError('Expected all "' + token.name + '" to match "' + token.pattern + '"')
           }
 
           path += (j === 0 ? token.prefix : token.delimiter) + segment
@@ -206,13 +167,25 @@ function tokensToFunction (tokens) {
         continue
       }
 
-      segment = token.asterisk ? encodeAsterisk(value) : encode(value)
+      if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
+        segment = encode(String(value))
 
-      if (!matches[i].test(segment)) {
-        throw new TypeError('Expected "' + token.name + '" to match "' + token.pattern + '", but received "' + segment + '"')
+        if (!matches[i].test(segment)) {
+          throw new TypeError('Expected "' + token.name + '" to match "' + token.pattern + '", but got "' + segment + '"')
+        }
+
+        path += token.prefix + segment
+        continue
       }
 
-      path += token.prefix + segment
+      if (token.optional) {
+        // Prepend partial segment prefixes.
+        if (token.partial) path += token.prefix
+
+        continue
+      }
+
+      throw new TypeError('Expected "' + token.name + '" to be ' + (token.repeat ? 'an array' : 'a string'))
     }
 
     return path
@@ -226,7 +199,7 @@ function tokensToFunction (tokens) {
  * @return {string}
  */
 function escapeString (str) {
-  return str.replace(/([.+*?=^!:${}()[\]|\/\\])/g, '\\$1')
+  return str.replace(/([.+*?=^!:${}()[\]|/\\])/g, '\\$1')
 }
 
 /**
@@ -236,19 +209,7 @@ function escapeString (str) {
  * @return {string}
  */
 function escapeGroup (group) {
-  return group.replace(/([=!:$\/()])/g, '\\$1')
-}
-
-/**
- * Attach the keys as a property of the regexp.
- *
- * @param  {!RegExp} re
- * @param  {Array}   keys
- * @return {!RegExp}
- */
-function attachKeys (re, keys) {
-  re.keys = keys
-  return re
+  return group.replace(/([=!:$/()])/g, '\\$1')
 }
 
 /**
@@ -258,17 +219,19 @@ function attachKeys (re, keys) {
  * @return {string}
  */
 function flags (options) {
-  return options.sensitive ? '' : 'i'
+  return options && options.sensitive ? '' : 'i'
 }
 
 /**
  * Pull out keys from a regexp.
  *
  * @param  {!RegExp} path
- * @param  {!Array}  keys
+ * @param  {Array=}  keys
  * @return {!RegExp}
  */
 function regexpToRegexp (path, keys) {
+  if (!keys) return path
+
   // Use a negative lookahead to match only capturing groups.
   var groups = path.source.match(/\((?!\?)/g)
 
@@ -281,21 +244,20 @@ function regexpToRegexp (path, keys) {
         optional: false,
         repeat: false,
         partial: false,
-        asterisk: false,
         pattern: null
       })
     }
   }
 
-  return attachKeys(path, keys)
+  return path
 }
 
 /**
  * Transform an array into a regexp.
  *
  * @param  {!Array}  path
- * @param  {Array}   keys
- * @param  {!Object} options
+ * @param  {Array=}  keys
+ * @param  {Object=} options
  * @return {!RegExp}
  */
 function arrayToRegexp (path, keys, options) {
@@ -305,17 +267,15 @@ function arrayToRegexp (path, keys, options) {
     parts.push(pathToRegexp(path[i], keys, options).source)
   }
 
-  var regexp = new RegExp('(?:' + parts.join('|') + ')', flags(options))
-
-  return attachKeys(regexp, keys)
+  return new RegExp('(?:' + parts.join('|') + ')', flags(options))
 }
 
 /**
  * Create a path regexp from string input.
  *
  * @param  {string}  path
- * @param  {!Array}  keys
- * @param  {!Object} options
+ * @param  {Array=}  keys
+ * @param  {Object=} options
  * @return {!RegExp}
  */
 function stringToRegexp (path, keys, options) {
@@ -325,21 +285,18 @@ function stringToRegexp (path, keys, options) {
 /**
  * Expose a function for taking tokens and returning a RegExp.
  *
- * @param  {!Array}          tokens
- * @param  {(Array|Object)=} keys
- * @param  {Object=}         options
+ * @param  {!Array}  tokens
+ * @param  {Array=}  keys
+ * @param  {Object=} options
  * @return {!RegExp}
  */
 function tokensToRegExp (tokens, keys, options) {
-  if (!isarray(keys)) {
-    options = /** @type {!Object} */ (keys || options)
-    keys = []
-  }
-
   options = options || {}
 
   var strict = options.strict
   var end = options.end !== false
+  var delimiter = escapeString(options.delimiter || '/')
+  var endsWith = [].concat(options.endsWith || []).map(escapeString).concat('$').join('|')
   var route = ''
 
   // Iterate over the tokens and create our regexp string.
@@ -352,7 +309,7 @@ function tokensToRegExp (tokens, keys, options) {
       var prefix = escapeString(token.prefix)
       var capture = '(?:' + token.pattern + ')'
 
-      keys.push(token)
+      if (keys) keys.push(token)
 
       if (token.repeat) {
         capture += '(?:' + prefix + capture + ')*'
@@ -372,26 +329,20 @@ function tokensToRegExp (tokens, keys, options) {
     }
   }
 
-  var delimiter = escapeString(options.delimiter || '/')
-  var endsWithDelimiter = route.slice(-delimiter.length) === delimiter
-
-  // In non-strict mode we allow a slash at the end of match. If the path to
-  // match already ends with a slash, we remove it for consistency. The slash
-  // is valid at the end of a path match, not in the middle. This is important
-  // in non-ending mode, where "/test/" shouldn't match "/test//route".
+  // In non-strict mode we allow a delimiter at the end of a match.
   if (!strict) {
-    route = (endsWithDelimiter ? route.slice(0, -delimiter.length) : route) + '(?:' + delimiter + '(?=$))?'
+    route += '(?:' + delimiter + '(?=' + endsWith + '))?'
   }
 
   if (end) {
-    route += '$'
+    route += endsWith === '$' ? endsWith : '(?=' + endsWith + ')'
   } else {
     // In non-ending mode, we need the capturing groups to match as much as
     // possible by using a positive lookahead to the end or next path segment.
-    route += strict && endsWithDelimiter ? '' : '(?=' + delimiter + '|$)'
+    route += '(?=' + delimiter + '|' + endsWith + ')'
   }
 
-  return attachKeys(new RegExp('^' + route, flags(options)), keys)
+  return new RegExp('^' + route, flags(options))
 }
 
 /**
@@ -402,25 +353,18 @@ function tokensToRegExp (tokens, keys, options) {
  * contain `[{ name: 'id', delimiter: '/', optional: false, repeat: false }]`.
  *
  * @param  {(string|RegExp|Array)} path
- * @param  {(Array|Object)=}       keys
+ * @param  {Array=}                keys
  * @param  {Object=}               options
  * @return {!RegExp}
  */
 function pathToRegexp (path, keys, options) {
-  if (!isarray(keys)) {
-    options = /** @type {!Object} */ (keys || options)
-    keys = []
-  }
-
-  options = options || {}
-
   if (path instanceof RegExp) {
-    return regexpToRegexp(path, /** @type {!Array} */ (keys))
+    return regexpToRegexp(path, keys)
   }
 
-  if (isarray(path)) {
-    return arrayToRegexp(/** @type {!Array} */ (path), /** @type {!Array} */ (keys), options)
+  if (Array.isArray(path)) {
+    return arrayToRegexp(/** @type {!Array} */ (path), keys, options)
   }
 
-  return stringToRegexp(/** @type {string} */ (path), /** @type {!Array} */ (keys), options)
+  return stringToRegexp(/** @type {string} */ (path), keys, options)
 }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
     "lint": "standard",
     "test-spec": "mocha --require ts-node/register -R spec --bail test.ts",
     "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require ts-node/register -R spec test.ts",
-    "prepublish": "typings install",
     "test": "npm run lint && npm run test-cov"
   },
   "keywords": [
@@ -33,15 +32,14 @@
     "url": "https://github.com/pillarjs/path-to-regexp.git"
   },
   "devDependencies": {
-    "chai": "^2.3.0",
-    "istanbul": "~0.3.0",
-    "mocha": "~2.2.4",
-    "standard": "~3.7.3",
-    "ts-node": "^0.5.5",
-    "typescript": "^1.8.7",
-    "typings": "^1.0.4"
-  },
-  "dependencies": {
-    "isarray": "1.0.0"
+    "@types/chai": "^4.0.4",
+    "@types/mocha": "^2.2.42",
+    "@types/node": "^8.0.24",
+    "chai": "^4.1.1",
+    "istanbul": "^0.4.5",
+    "mocha": "^3.5.0",
+    "standard": "^10.0.3",
+    "ts-node": "^3.3.0",
+    "typescript": "^2.4.2"
   }
 }

--- a/test.ts
+++ b/test.ts
@@ -1,7 +1,5 @@
 /* global describe, it */
 
-/// <reference path="typings/index.d.ts" />
-
 import util = require('util')
 import chai = require('chai')
 import pathToRegexp = require('./index')
@@ -13,7 +11,7 @@ type Test = [
   pathToRegexp.RegExpOptions & pathToRegexp.ParseOptions,
   pathToRegexp.Token[],
   Array<[string, string[]]>,
-  Array<[any, string]>
+  Array<[any, string] | [any, string, pathToRegexp.PathFunctionOptions]>
 ]
 
 /**
@@ -65,9 +63,9 @@ var TESTS: Test[] = [
       '/test/'
     ],
     [
-      ['/test', ['/test']],
+      ['/test', null],
       ['/test/', ['/test/']],
-      ['/test//', null]
+      ['/test//', ['/test//']]
     ],
     [
       [null, '/test/']
@@ -178,9 +176,9 @@ var TESTS: Test[] = [
       '/test/'
     ],
     [
-      ['/test/route', ['/test']],
-      ['/test//', ['/test']],
-      ['/test//route', ['/test']]
+      ['/test/route', null],
+      ['/test//', ['/test//']],
+      ['/test//route', ['/test/']]
     ],
     [
       [null, '/test/']
@@ -199,7 +197,6 @@ var TESTS: Test[] = [
         optional: false,
         repeat: false,
         partial: false,
-        asterisk: false,
         pattern: '[^\\/]+?'
       }
     ],
@@ -208,7 +205,9 @@ var TESTS: Test[] = [
     ],
     [
       [{}, null],
-      [{ test: 'abc' }, '/abc']
+      [{ test: 'abc' }, '/abc'],
+      [{ test: 'a+b' }, '/a+b', { encode: (value) => value }],
+      [{ test: 'a+b' }, '/a%2Bb']
     ]
   ],
   [
@@ -224,13 +223,13 @@ var TESTS: Test[] = [
         optional: false,
         repeat: false,
         partial: false,
-        asterisk: false,
         pattern: '[^\\/]+?'
       },
       '/'
     ],
     [
-      ['/route', ['/route', 'route']]
+      ['/route', null],
+      ['/route/', ['/route/', 'route']]
     ],
     [
       [{ test: 'abc' }, '/abc/']
@@ -271,7 +270,7 @@ var TESTS: Test[] = [
       ['/test', null],
       ['/test/', ['/test/']],
       ['/test//', ['/test/']],
-      ['/test/route', ['/test/']]
+      ['/test/route', null]
     ],
     [
       [null, '/test/']
@@ -309,7 +308,6 @@ var TESTS: Test[] = [
         optional: false,
         repeat: false,
         partial: false,
-        asterisk: false,
         pattern: '[^\\/]+?'
       }
     ],
@@ -336,7 +334,6 @@ var TESTS: Test[] = [
         optional: false,
         repeat: false,
         partial: false,
-        asterisk: false,
         pattern: '[^\\/]+?'
       },
       '/'
@@ -399,7 +396,6 @@ var TESTS: Test[] = [
         optional: false,
         repeat: false,
         partial: false,
-        asterisk: false,
         pattern: '[^\\/]+?'
       }
     ],
@@ -431,7 +427,6 @@ var TESTS: Test[] = [
         optional: false,
         repeat: false,
         partial: false,
-        asterisk: false,
         pattern: '[^\\/]+?'
       }
     ],
@@ -456,7 +451,6 @@ var TESTS: Test[] = [
         optional: false,
         repeat: false,
         partial: false,
-        asterisk: false,
         pattern: '[^\\/]+?'
       },
       '/'
@@ -482,7 +476,6 @@ var TESTS: Test[] = [
         optional: false,
         repeat: false,
         partial: false,
-        asterisk: false,
         pattern: '[^\\/]+?'
       }
     ],
@@ -509,7 +502,6 @@ var TESTS: Test[] = [
         optional: true,
         repeat: false,
         partial: false,
-        asterisk: false,
         pattern: '[^\\/]+?'
       }
     ],
@@ -537,7 +529,6 @@ var TESTS: Test[] = [
         optional: true,
         repeat: false,
         partial: false,
-        asterisk: false,
         pattern: '[^\\/]+?'
       }
     ],
@@ -564,7 +555,6 @@ var TESTS: Test[] = [
         optional: true,
         repeat: false,
         partial: false,
-        asterisk: false,
         pattern: '[^\\/]+?'
       },
       '/'
@@ -591,7 +581,6 @@ var TESTS: Test[] = [
         optional: true,
         repeat: false,
         partial: false,
-        asterisk: false,
         pattern: '[^\\/]+?'
       },
       '/bar'
@@ -614,7 +603,6 @@ var TESTS: Test[] = [
         optional: true,
         repeat: false,
         partial: true,
-        asterisk: false,
         pattern: '[^\\/]+?'
       },
       '-bar'
@@ -622,6 +610,31 @@ var TESTS: Test[] = [
     [
       ['/-bar', ['/-bar', undefined]],
       ['/foo-bar', ['/foo-bar', 'foo']]
+    ],
+    [
+      [undefined, '/-bar'],
+      [{ test: 'foo' }, '/foo-bar']
+    ]
+  ],
+  [
+    '/:test*-bar',
+    null,
+    [
+      {
+        name: 'test',
+        prefix: '/',
+        delimiter: '/',
+        optional: true,
+        repeat: true,
+        partial: true,
+        pattern: '[^\\/]+?'
+      },
+      '-bar'
+    ],
+    [
+      ['/-bar', ['/-bar', undefined]],
+      ['/foo-bar', ['/foo-bar', 'foo']],
+      ['/foo/baz-bar', ['/foo/baz-bar', 'foo/baz']],
     ],
     [
       [{ test: 'foo' }, '/foo-bar']
@@ -642,7 +655,6 @@ var TESTS: Test[] = [
         optional: false,
         repeat: true,
         partial: false,
-        asterisk: false,
         pattern: '[^\\/]+?'
       }
     ],
@@ -669,7 +681,6 @@ var TESTS: Test[] = [
         optional: false,
         repeat: true,
         partial: false,
-        asterisk: false,
         pattern: '\\d+'
       }
     ],
@@ -695,7 +706,6 @@ var TESTS: Test[] = [
         optional: false,
         repeat: true,
         partial: false,
-        asterisk: false,
         pattern: 'json|xml'
       }
     ],
@@ -726,7 +736,6 @@ var TESTS: Test[] = [
         optional: true,
         repeat: true,
         partial: false,
-        asterisk: false,
         pattern: '[^\\/]+?'
       }
     ],
@@ -754,7 +763,6 @@ var TESTS: Test[] = [
         optional: true,
         repeat: true,
         partial: false,
-        asterisk: false,
         pattern: '[a-z]+'
       }
     ],
@@ -787,7 +795,6 @@ var TESTS: Test[] = [
         optional: false,
         repeat: false,
         partial: false,
-        asterisk: false,
         pattern: '\\d+'
       }
     ],
@@ -814,7 +821,6 @@ var TESTS: Test[] = [
         optional: false,
         repeat: false,
         partial: false,
-        asterisk: false,
         pattern: '\\d+'
       }
     ],
@@ -838,7 +844,6 @@ var TESTS: Test[] = [
         optional: false,
         repeat: false,
         partial: false,
-        asterisk: false,
         pattern: '.*'
       }
     ],
@@ -864,7 +869,6 @@ var TESTS: Test[] = [
         optional: false,
         repeat: false,
         partial: false,
-        asterisk: false,
         pattern: '[a-z]+'
       }
     ],
@@ -889,7 +893,6 @@ var TESTS: Test[] = [
         optional: false,
         repeat: false,
         partial: false,
-        asterisk: false,
         pattern: 'this|that'
       }
     ],
@@ -915,7 +918,6 @@ var TESTS: Test[] = [
         optional: true,
         repeat: true,
         partial: false,
-        asterisk: false,
         pattern: 'abc|xyz'
       }
     ],
@@ -964,7 +966,6 @@ var TESTS: Test[] = [
         optional: false,
         repeat: false,
         partial: false,
-        asterisk: false,
         pattern: '[^\\/]+?'
       }
     ],
@@ -993,7 +994,6 @@ var TESTS: Test[] = [
         optional: false,
         repeat: false,
         partial: false,
-        asterisk: false,
         pattern: '[^\\/]+?'
       }
     ],
@@ -1019,7 +1019,6 @@ var TESTS: Test[] = [
         optional: false,
         repeat: false,
         partial: false,
-        asterisk: false,
         pattern: '[^\\/]+?'
       }
     ],
@@ -1044,7 +1043,6 @@ var TESTS: Test[] = [
         optional: true,
         repeat: false,
         partial: false,
-        asterisk: false,
         pattern: '[^\\/]+?'
       }
     ],
@@ -1089,7 +1087,6 @@ var TESTS: Test[] = [
         optional: false,
         repeat: false,
         partial: true,
-        asterisk: false,
         pattern: '[^\\/]+?'
       },
       '.json'
@@ -1121,7 +1118,6 @@ var TESTS: Test[] = [
         optional: false,
         repeat: false,
         partial: false,
-        asterisk: false,
         pattern: '[^\\.]+?'
       }
     ],
@@ -1147,7 +1143,6 @@ var TESTS: Test[] = [
         optional: false,
         repeat: false,
         partial: false,
-        asterisk: false,
         pattern: '[^\\.]+?'
       },
       {
@@ -1157,7 +1152,6 @@ var TESTS: Test[] = [
         optional: false,
         repeat: false,
         partial: false,
-        asterisk: false,
         pattern: '[^\\.]+?'
       }
     ],
@@ -1182,7 +1176,6 @@ var TESTS: Test[] = [
         optional: false,
         repeat: true,
         partial: false,
-        asterisk: false,
         pattern: '[^\\.]+?'
       }
     ],
@@ -1210,7 +1203,6 @@ var TESTS: Test[] = [
         optional: false,
         repeat: false,
         partial: false,
-        asterisk: false,
         pattern: '[^\\.]+?'
       }
     ],
@@ -1234,7 +1226,6 @@ var TESTS: Test[] = [
         optional: false,
         repeat: false,
         partial: false,
-        asterisk: false,
         pattern: '[^\\.]+?'
       },
       '.'
@@ -1263,7 +1254,6 @@ var TESTS: Test[] = [
         optional: false,
         repeat: false,
         partial: true,
-        asterisk: false,
         pattern: '[^\\/]+?'
       },
       {
@@ -1273,7 +1263,6 @@ var TESTS: Test[] = [
         optional: false,
         repeat: false,
         partial: false,
-        asterisk: false,
         pattern: '[^\\.]+?'
       }
     ],
@@ -1298,7 +1287,6 @@ var TESTS: Test[] = [
         optional: false,
         repeat: false,
         partial: true,
-        asterisk: false,
         pattern: '[^\\/]+?'
       },
       {
@@ -1308,7 +1296,6 @@ var TESTS: Test[] = [
         optional: true,
         repeat: false,
         partial: false,
-        asterisk: false,
         pattern: '[^\\.]+?'
       }
     ],
@@ -1336,7 +1323,6 @@ var TESTS: Test[] = [
         optional: false,
         repeat: false,
         partial: true,
-        asterisk: false,
         pattern: '[^\\/]+?'
       },
       {
@@ -1346,7 +1332,6 @@ var TESTS: Test[] = [
         optional: true,
         repeat: false,
         partial: false,
-        asterisk: false,
         pattern: '[^\\.]+?'
       }
     ],
@@ -1376,7 +1361,6 @@ var TESTS: Test[] = [
         optional: false,
         repeat: false,
         partial: true,
-        asterisk: false,
         pattern: '.*'
       },
       'z'
@@ -1407,7 +1391,6 @@ var TESTS: Test[] = [
         optional: false,
         repeat: false,
         partial: false,
-        asterisk: false,
         pattern: '\\d+'
       }
     ],
@@ -1434,7 +1417,6 @@ var TESTS: Test[] = [
         optional: false,
         repeat: false,
         partial: false,
-        asterisk: false,
         pattern: '\\d+'
       }
     ],
@@ -1459,7 +1441,6 @@ var TESTS: Test[] = [
         optional: true,
         repeat: false,
         partial: false,
-        asterisk: false,
         pattern: '\\d+'
       }
     ],
@@ -1483,7 +1464,6 @@ var TESTS: Test[] = [
         optional: false,
         repeat: false,
         partial: false,
-        asterisk: false,
         pattern: '.*'
       }
     ],
@@ -1509,7 +1489,6 @@ var TESTS: Test[] = [
         optional: false,
         repeat: false,
         partial: false,
-        asterisk: false,
         pattern: '\\d+\\\\'
       },
       ')'
@@ -1543,7 +1522,6 @@ var TESTS: Test[] = [
         optional: false,
         repeat: false,
         partial: false,
-        asterisk: false,
         pattern: null
       }
     ],
@@ -1563,7 +1541,6 @@ var TESTS: Test[] = [
         optional: false,
         repeat: false,
         partial: false,
-        asterisk: false,
         pattern: null
       }
     ],
@@ -1588,7 +1565,6 @@ var TESTS: Test[] = [
         optional: false,
         repeat: false,
         partial: false,
-        asterisk: false,
         pattern: null
       }
     ],
@@ -1608,7 +1584,6 @@ var TESTS: Test[] = [
         optional: false,
         repeat: false,
         partial: false,
-        asterisk: false,
         pattern: '\\d+'
       },
       {
@@ -1618,7 +1593,6 @@ var TESTS: Test[] = [
         optional: false,
         repeat: false,
         partial: false,
-        asterisk: false,
         pattern: null
       }
     ],
@@ -1643,7 +1617,6 @@ var TESTS: Test[] = [
         optional: false,
         repeat: false,
         partial: false,
-        asterisk: false,
         pattern: '[^\\/]+?'
       },
       {
@@ -1653,7 +1626,6 @@ var TESTS: Test[] = [
         optional: false,
         repeat: false,
         partial: false,
-        asterisk: false,
         pattern: '[^\\/]+?'
       }
     ],
@@ -1674,7 +1646,6 @@ var TESTS: Test[] = [
         optional: false,
         repeat: false,
         partial: false,
-        asterisk: false,
         pattern: null
       },
       {
@@ -1684,7 +1655,6 @@ var TESTS: Test[] = [
         optional: false,
         repeat: false,
         partial: false,
-        asterisk: false,
         pattern: null
       }
     ],
@@ -1726,7 +1696,7 @@ var TESTS: Test[] = [
     ]
   ],
   [
-    '/.+\\*?=^!:${}[]|',
+    '/.+*?=^!:${}[]|',
     null,
     [
       '/.+*?=^!:${}[]|'
@@ -1738,103 +1708,40 @@ var TESTS: Test[] = [
       [null, '/.+*?=^!:${}[]|']
     ]
   ],
-
-  /**
-   * Asterisk functionality.
-   */
   [
-    '/*',
+    '/test\\/:uid(u\\d+)?:cid(c\\d+)?',
     null,
     [
+      '/test/',
       {
-        name: 0,
-        prefix: '/',
+        name: 'uid',
+        prefix: '',
         delimiter: '/',
-        optional: false,
+        optional: true,
         repeat: false,
         partial: false,
-        asterisk: true,
-        pattern: '.*'
-      }
-    ],
-    [
-      ['', null],
-      ['/', ['/', '']],
-      ['/foo/bar', ['/foo/bar', 'foo/bar']]
-    ],
-    [
-      [null, null],
-      [{ '0': '' }, '/'],
-      [{ '0': 'foobar' }, '/foobar'],
-      [{ '0': 'foo/bar' }, '/foo/bar'],
-      [{ '0': ['foo', 'bar'] }, null],
-      [{ '0': 'foo/bar?baz' }, '/foo/bar%3Fbaz']
-    ]
-  ],
-  [
-    '/foo/*',
-    null,
-    [
-      '/foo',
-      {
-        name: 0,
-        prefix: '/',
-        delimiter: '/',
-        optional: false,
-        repeat: false,
-        partial: false,
-        asterisk: true,
-        pattern: '.*'
-      }
-    ],
-    [
-      ['', null],
-      ['/test', null],
-      ['/foo', null],
-      ['/foo/', ['/foo/', '']],
-      ['/foo/bar', ['/foo/bar', 'bar']]
-    ],
-    [
-      [{ '0': 'bar' }, '/foo/bar']
-    ]
-  ],
-  [
-    '/:foo/*',
-    null,
-    [
-      {
-        name: 'foo',
-        prefix: '/',
-        delimiter: '/',
-        optional: false,
-        repeat: false,
-        partial: false,
-        asterisk: false,
-        pattern: '[^\\/]+?'
+        pattern: 'u\\d+'
       },
       {
-        name: 0,
-        prefix: '/',
+        name: 'cid',
+        prefix: '',
         delimiter: '/',
-        optional: false,
+        optional: true,
         repeat: false,
         partial: false,
-        asterisk: true,
-        pattern: '.*'
+        pattern: 'c\\d+'
       }
     ],
     [
-      ['', null],
       ['/test', null],
-      ['/foo', null],
-      ['/foo/', ['/foo/', 'foo', '']],
-      ['/foo/bar', ['/foo/bar', 'foo', 'bar']]
+      ['/test/', ['/test/', undefined, undefined]],
+      ['/test/u123', ['/test/u123', 'u123', undefined]],
+      ['/test/c123', ['/test/c123', undefined, 'c123']],
     ],
     [
-      [{ foo: 'foo' }, null],
-      [{ '0': 'bar' }, null],
-      [{ foo: 'foo', '0': 'bar' }, '/foo/bar'],
-      [{ foo: 'a', '0': 'b/c' }, '/a/b/c']
+      [{ uid: 'u123' }, '/test/u123'],
+      [{ cid: 'c123' }, '/test/c123'],
+      [{ cid: 'u123' }, null]
     ]
   ],
 
@@ -1852,7 +1759,6 @@ var TESTS: Test[] = [
         optional: true,
         repeat: false,
         partial: true,
-        asterisk: false,
         pattern: 'apple-'
       },
       'icon-',
@@ -1863,7 +1769,6 @@ var TESTS: Test[] = [
         optional: false,
         repeat: false,
         partial: false,
-        asterisk: false,
         pattern: '\\d+'
       },
       '.png'
@@ -1889,7 +1794,6 @@ var TESTS: Test[] = [
         optional: false,
         repeat: false,
         partial: false,
-        asterisk: false,
         pattern: '[^\\/]+?'
       },
       {
@@ -1899,7 +1803,6 @@ var TESTS: Test[] = [
         optional: false,
         repeat: false,
         partial: false,
-        asterisk: false,
         pattern: '[^\\/]+?'
       }
     ],
@@ -1921,7 +1824,6 @@ var TESTS: Test[] = [
         optional: false,
         repeat: false,
         partial: true,
-        asterisk: false,
         pattern: '[^\\/]+?'
       },
       '(test)/bar'
@@ -1940,7 +1842,6 @@ var TESTS: Test[] = [
         optional: false,
         repeat: false,
         partial: false,
-        asterisk: false,
         pattern: '[\\w-.]+'
       },
       {
@@ -1950,7 +1851,6 @@ var TESTS: Test[] = [
         optional: false,
         repeat: false,
         partial: false,
-        asterisk: false,
         pattern: '[\\w-]+'
       }
     ],
@@ -1975,7 +1875,6 @@ var TESTS: Test[] = [
         optional: false,
         repeat: false,
         partial: true,
-        asterisk: false,
         pattern: '[^\\/]+?'
       },
       '?'
@@ -1998,7 +1897,6 @@ var TESTS: Test[] = [
         optional: false,
         repeat: true,
         partial: true,
-        asterisk: false,
         pattern: '[^\\/]+?'
       },
       'baz'
@@ -2025,7 +1923,6 @@ var TESTS: Test[] = [
         optional: true,
         repeat: false,
         partial: true,
-        asterisk: false,
         pattern: '[^\\/]+?'
       },
       'baz'
@@ -2050,7 +1947,6 @@ var TESTS: Test[] = [
         optional: false,
         repeat: false,
         partial: true,
-        asterisk: false,
         pattern: '[^\\/]+?'
       },
       '(',
@@ -2061,7 +1957,6 @@ var TESTS: Test[] = [
         optional: true,
         repeat: false,
         partial: false,
-        asterisk: false,
         pattern: '[^\\/]+?'
       },
       ')'
@@ -2086,7 +1981,6 @@ var TESTS: Test[] = [
         optional: false,
         repeat: false,
         partial: true,
-        asterisk: false,
         pattern: 'video|audio|text'
       },
       {
@@ -2096,7 +1990,6 @@ var TESTS: Test[] = [
         optional: true,
         repeat: false,
         partial: false,
-        asterisk: false,
         pattern: '\\+.+'
       }
     ],
@@ -2125,7 +2018,6 @@ var TESTS: Test[] = [
         optional: false,
         repeat: false,
         partial: false,
-        asterisk: false,
         pattern: '[^\\/]+?'
       }
     ],
@@ -2134,6 +2026,19 @@ var TESTS: Test[] = [
     ],
     [
       [{ foo: 'café' }, '/caf%C3%A9']
+    ]
+  ],
+  [
+    '/café',
+    null,
+    [
+      '/café'
+    ],
+    [
+      ['/café', ['/café']]
+    ],
+    [
+      [null, '/café']
     ]
   ],
 
@@ -2153,7 +2058,6 @@ var TESTS: Test[] = [
         optional: false,
         repeat: false,
         partial: false,
-        asterisk: false,
         pattern: '[^\\.]+?'
       },
       '.com'
@@ -2181,7 +2085,6 @@ var TESTS: Test[] = [
         optional: false,
         repeat: false,
         partial: false,
-        asterisk: false,
         pattern: '[^\\.]+?'
       },
       '.com'
@@ -2209,7 +2112,6 @@ var TESTS: Test[] = [
         optional: false,
         repeat: false,
         partial: false,
-        asterisk: false,
         pattern: '[^\\.]+?'
       }
     ],
@@ -2238,7 +2140,84 @@ var TESTS: Test[] = [
     [
       [null, 'this is']
     ]
-  ]
+  ],
+
+  /**
+   * Ends with.
+   */
+  [
+    '/test',
+    {
+      endsWith: '?'
+    },
+    [
+      '/test'
+    ],
+    [
+      ['/test', ['/test']],
+      ['/test?query=string', ['/test']],
+      ['/test/?query=string', ['/test/']],
+      ['/testx', null]
+    ],
+    [
+      [null, '/test']
+    ]
+  ],
+  [
+    '/test',
+    {
+      endsWith: '?',
+      strict: true
+    },
+    [
+      '/test'
+    ],
+    [
+      ['/test?query=string', ['/test']],
+      ['/test/?query=string', null]
+    ],
+    [
+      [null, '/test']
+    ]
+  ],
+
+  /**
+   * Custom delimiters.
+   */
+  [
+    '$:foo$:bar?',
+    {
+      delimiters: '$'
+    },
+    [
+      {
+        delimiter: '$',
+        name: 'foo',
+        optional: false,
+        partial: false,
+        pattern: '[^\\$]+?',
+        prefix: '$',
+        repeat: false
+      },
+      {
+        delimiter: '$',
+        name: 'bar',
+        optional: true,
+        partial: false,
+        pattern: '[^\\$]+?',
+        prefix: '$',
+        repeat: false
+      }
+    ],
+    [
+      ['$x', ['$x', 'x', undefined]],
+      ['$x$y', ['$x$y', 'x', 'y']]
+    ],
+    [
+      [{ foo: 'foo' }, '$foo'],
+      [{ foo: 'foo', bar: 'bar' }, '$foo$bar'],
+    ]
+  ],
 ]
 
 /**
@@ -2254,7 +2233,6 @@ describe('path-to-regexp', function () {
     optional: false,
     repeat: false,
     partial: false,
-    asterisk: false,
     pattern: '[^\\/]+?'
   }
 
@@ -2262,33 +2240,22 @@ describe('path-to-regexp', function () {
     it('should work without different call combinations', function () {
       pathToRegexp('/test')
       pathToRegexp('/test', [])
-      pathToRegexp('/test', {})
-      pathToRegexp('/test', [], {})
+      pathToRegexp('/test', undefined, {})
 
       pathToRegexp(/^\/test/)
       pathToRegexp(/^\/test/, [])
-      pathToRegexp(/^\/test/, {})
-      pathToRegexp(/^\/test/, [], {})
+      pathToRegexp(/^\/test/, null, {})
 
       pathToRegexp(['/a', '/b'])
       pathToRegexp(['/a', '/b'], [])
-      pathToRegexp(['/a', '/b'], {})
-      pathToRegexp(['/a', '/b'], [], {})
+      pathToRegexp(['/a', '/b'], null, {})
     })
 
     it('should accept an array of keys as the second argument', function () {
       var keys = []
       var re = pathToRegexp(TEST_PATH, keys, { end: false })
 
-      expect(re.keys).to.equal(keys)
       expect(keys).to.deep.equal([TEST_PARAM])
-      expect(exec(re, '/user/123/show')).to.deep.equal(['/user/123', '123'])
-    })
-
-    it('should work with keys as null', function () {
-      var re = pathToRegexp(TEST_PATH, null, { end: false })
-
-      expect(re.keys).to.deep.equal([TEST_PARAM])
       expect(exec(re, '/user/123/show')).to.deep.equal(['/user/123', '123'])
     })
   })
@@ -2317,34 +2284,32 @@ describe('path-to-regexp', function () {
       var matchCases = test[3]
       var compileCases = test[4]
 
-      var keys = tokens.filter(function (token) {
-        return typeof token !== 'string'
-      })
-
       describe(util.inspect(path), function () {
-        var re = pathToRegexp(path, opts)
+        var keys = []
+        var re = pathToRegexp(path, keys, opts)
 
         // Parsing and compiling is only supported with string input.
         if (typeof path === 'string') {
           it('should parse', function () {
-            expect(pathToRegexp.parse(path, opts)).to.deep.equal(tokens)
+            expect(pathToRegexp.parse(path as string, opts)).to.deep.equal(tokens)
           })
 
           describe('compile', function () {
-            var toPath = pathToRegexp.compile(path)
+            var toPath = pathToRegexp.compile(path as string, opts)
 
             compileCases.forEach(function (io) {
               var input = io[0]
               var output = io[1]
+              var options = io[2]
 
               if (output != null) {
                 it('should compile using ' + util.inspect(input), function () {
-                  expect(toPath(input)).to.equal(output)
+                  expect(toPath(input, options)).to.equal(output)
                 })
               } else {
                 it('should not compile using ' + util.inspect(input), function () {
                   expect(function () {
-                    toPath(input)
+                    toPath(input, options)
                   }).to.throw(TypeError)
                 })
               }
@@ -2352,7 +2317,9 @@ describe('path-to-regexp', function () {
           })
         } else {
           it('should parse keys', function () {
-            expect(re.keys).to.deep.equal(keys)
+            expect(keys).to.deep.equal(tokens.filter(function (token) {
+              return typeof token !== 'string'
+            }))
           })
         }
 
@@ -2371,23 +2338,13 @@ describe('path-to-regexp', function () {
     })
   })
 
-  describe('compile', function () {
-    it('should allow pretty option', function () {
-      var value = ';,:@&=+$-_.!~*()'
-      var toPath = pathToRegexp.compile('/:value')
-      var path = toPath({ value }, { pretty: true })
-
-      expect(path).to.equal(`/${value}`)
-    })
-  })
-
   describe('compile errors', function () {
     it('should throw when a required param is undefined', function () {
       var toPath = pathToRegexp.compile('/a/:b/c')
 
       expect(function () {
         toPath()
-      }).to.throw(TypeError, 'Expected "b" to be defined')
+      }).to.throw(TypeError, 'Expected "b" to be a string')
     })
 
     it('should throw when it does not match the pattern', function () {

--- a/typings.json
+++ b/typings.json
@@ -1,9 +1,0 @@
-{
-  "devDependencies": {
-    "chai": "registry:npm/chai#3.5.0+20160415060238"
-  },
-  "globalDevDependencies": {
-    "mocha": "registry:env/mocha#2.2.5+20160321223601",
-    "node": "registry:env/node#4.0.0+20160507210304"
-  }
-}


### PR DESCRIPTION
* New option! Ability to set `endsWith` to match paths like `/test?query=string` up to the query string
* New option! Set `delimiters` for specific characters to be treated as parameter prefixes (e.g. `/:test`)
* Remove `isarray` dependency
* Explicitly handle trailing delimiters instead of trimming them (e.g. `/test/` is now treated as `/test/` instead of `/test` when matching)
* Remove overloaded `keys` argument that accepted `options`
* Remove `keys` list attached to the `RegExp` output
* Remove asterisk functionality (it's a real pain to properly encode)
* Change `tokensToFunction` (e.g. `compile`) to accept an `encode` function for pretty encoding (e.g. pass your own implementation)