### PR TITLE
Better asterisk functionality

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,9 +19,10 @@ var PATH_REGEXP = new RegExp([
   // Match Express-style parameters and un-named parameters with a prefix
   // and optional suffixes. Matches appear as:
   //
-  // "/:test(\\d+)?" => ["/", "test", "\d+", undefined, "?"]
-  // "/route(\\d+)"  => [undefined, undefined, undefined, "\d+", undefined]
-  '(?:\\:(\\w+)(?:\\(((?:\\\\.|[^\\\\()])+)\\))?|\\(((?:\\\\.|[^\\\\()])+)\\))([+*?])?'
+  // "/:?" => [undefined, undefined, undefined, "?"]
+  // "/:test(\\d+)?" => ["test", "\d+", undefined, "?"]
+  // "/route(\\d+)"  => [undefined, undefined, "\d+", undefined]
+  '(?:\\:(\\w*)(?:\\(((?:\\\\.|[^\\\\()])+)\\))?|\\(((?:\\\\.|[^\\\\()])+)\\))([+*?])?'
 ].join('|'), 'g')
 
 /**

--- a/test.ts
+++ b/test.ts
@@ -1696,7 +1696,7 @@ var TESTS: Test[] = [
     ]
   ],
   [
-    '/.+*?=^!:${}[]|',
+    '/.+*?=^!\\:${}[]|',
     null,
     [
       '/.+*?=^!:${}[]|'
@@ -2218,6 +2218,63 @@ var TESTS: Test[] = [
       [{ foo: 'foo', bar: 'bar' }, '$foo$bar'],
     ]
   ],
+
+   /**
+   * Unnamed modifiers.
+   */
+  [
+    '/:*',
+    null,
+    [
+      {
+        name: 0,
+        prefix: '/',
+        delimiter: '/',
+        optional: true,
+        repeat: true,
+        partial: false,
+        pattern: '[^\\/]+?'
+      }
+    ],
+    [
+      ['', ['', undefined]],
+      ['/', ['/', undefined]],
+      ['/foo/bar', ['/foo/bar', 'foo/bar']]
+    ],
+    [
+      [null, ''],
+      [{ '0': '' }, null],
+      [{ '0': 'foobar' }, '/foobar'],
+      [{ '0': ['foo', 'bar'] }, '/foo/bar'],
+      [{ '0': 'foo/bar' }, '/foo%2Fbar']
+    ]
+  ],
+  [
+    '/foo/:*',
+    null,
+    [
+      '/foo',
+      {
+        name: 0,
+        prefix: '/',
+        delimiter: '/',
+        optional: true,
+        repeat: true,
+        partial: false,
+        pattern: '[^\\/]+?'
+      }
+    ],
+    [
+      ['', null],
+      ['/test', null],
+      ['/foo', ['/foo', undefined]],
+      ['/foo/', ['/foo/', undefined]],
+      ['/foo/bar', ['/foo/bar', 'bar']]
+    ],
+    [
+      [{ '0': 'bar' }, '/foo/bar']
+    ]
+  ]
 ]
 
 /**


### PR DESCRIPTION
/cc @DylanPiercey from https://github.com/pillarjs/path-to-regexp/issues/87 for review. Proper `*` behaviour that's incompatible with Express.js (in the strictest sense) but compatible with expectations.