### PR TITLE
Pass `token` to the encode function

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -172,7 +172,7 @@ toPath({ id: 'café' }) //=> "/user/caf%C3%A9"
 toPath({ id: '/' }) //=> "/user/%2F"
 
 toPath({ id: ':/' }) //=> "/user/%3A%2F"
-toPath({ id: ':/' }, { encode: (x) => x }) //=> "/user/:/"
+toPath({ id: ':/' }, { encode: (value, token) => value }) //=> "/user/:/"
 
 var toPathRepeated = pathToRegexp.compile('/:segment+')
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -69,7 +69,7 @@ declare namespace pathToRegexp {
     /**
      * Function for encoding input strings for output.
      */
-    encode?: (value: string) => string;
+    encode?: (value: string, token: Key) => string;
   }
 
   export type Token = string | Key;

--- a/index.js
+++ b/index.js
@@ -161,7 +161,7 @@ function tokensToFunction (tokens) {
         }
 
         for (var j = 0; j < value.length; j++) {
-          segment = encode(value[j])
+          segment = encode(value[j], token)
 
           if (!matches[i].test(segment)) {
             throw new TypeError('Expected all "' + token.name + '" to match "' + token.pattern + '"')
@@ -174,7 +174,7 @@ function tokensToFunction (tokens) {
       }
 
       if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
-        segment = encode(String(value))
+        segment = encode(String(value), token)
 
         if (!matches[i].test(segment)) {
           throw new TypeError('Expected "' + token.name + '" to match "' + token.pattern + '", but got "' + segment + '"')

--- a/test.ts
+++ b/test.ts
@@ -208,6 +208,7 @@ var TESTS: Test[] = [
       [{}, null],
       [{ test: 'abc' }, '/abc'],
       [{ test: 'a+b' }, '/a+b', { encode: (value) => value }],
+      [{ test: 'a+b' }, '/test', { encode: (_, token) => String(token.name) }],
       [{ test: 'a+b' }, '/a%2Bb']
     ]
   ],


### PR DESCRIPTION
Supports https://github.com/pillarjs/path-to-regexp/issues/137.