### PR TITLE
Fix matching empty string with `end: false`

### DIFF
--- a/index.js
+++ b/index.js
@@ -305,7 +305,7 @@ function tokensToRegExp (tokens, keys, options) {
   var delimiters = options.delimiters || DEFAULT_DELIMITERS
   var endsWith = [].concat(options.endsWith || []).map(escapeString).concat('$').join('|')
   var route = ''
-  var isEndDelimited = false
+  var isEndDelimited = tokens.length === 0
 
   // Iterate over the tokens and create our regexp string.
   for (var i = 0; i < tokens.length; i++) {

--- a/test.ts
+++ b/test.ts
@@ -237,6 +237,23 @@ var TESTS: Test[] = [
       [{ test: 'abc' }, '/abc/']
     ]
   ],
+  [
+    '',
+    {
+      end: false
+    },
+    [],
+    [
+      ['', ['']],
+      ['/', ['/']],
+      ['route', ['']],
+      ['/route', ['']],
+      ['/route/', ['']]
+    ],
+    [
+      [null, '']
+    ]
+  ],
 
   /**
    * Combine modes.


### PR DESCRIPTION
Closes https://github.com/pillarjs/path-to-regexp/issues/148.