### PR TITLE
Add `noValidate` option in `PathFunctionOptions`

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -193,6 +193,7 @@ const toPathRegexp = pathToRegexp.compile('/user/:id(\\d+)')
 toPathRegexp({ id: 123 }) //=> "/user/123"
 toPathRegexp({ id: '123' }) //=> "/user/123"
 toPathRegexp({ id: 'abc' }) //=> Throws `TypeError`.
+toPathRegexp({ id: 'abc' }, { noValidate: true }) //=> "/user/abc"
 ```
 
 **Note:** The generated function will throw on invalid input. It will do all necessary checks to ensure the generated path is valid. This method only works with strings.

--- a/index.d.ts
+++ b/index.d.ts
@@ -73,6 +73,7 @@ declare namespace pathToRegexp {
      * Function for encoding input strings for output.
      */
     encode?: (value: string, token: Key) => string;
+    skipMatch?: boolean;
   }
 
   export type Token = string | Key;

--- a/index.d.ts
+++ b/index.d.ts
@@ -73,7 +73,10 @@ declare namespace pathToRegexp {
      * Function for encoding input strings for output.
      */
     encode?: (value: string, token: Key) => string;
-    skipMatch?: boolean;
+    /**
+     * When `true` the path generator will skip token validate.
+     */
+    noValidate?: boolean;
   }
 
   export type Token = string | Key;

--- a/index.d.ts
+++ b/index.d.ts
@@ -74,7 +74,7 @@ declare namespace pathToRegexp {
      */
     encode?: (value: string, token: Key) => string;
     /**
-     * When `true` the path generator will skip token validate.
+     * When `true` the function can produce an invalid (unmatched) path. (default: `false`)
      */
     noValidate?: boolean;
   }

--- a/index.js
+++ b/index.js
@@ -137,6 +137,7 @@ function tokensToFunction (tokens) {
   return function (data, options) {
     var path = ''
     var encode = (options && options.encode) || encodeURIComponent
+    var skipMatch = (options && options.skipMatch) || false
 
     for (var i = 0; i < tokens.length; i++) {
       var token = tokens[i]
@@ -163,7 +164,7 @@ function tokensToFunction (tokens) {
         for (var j = 0; j < value.length; j++) {
           segment = encode(value[j], token)
 
-          if (!matches[i].test(segment)) {
+          if (!skipMatch && !matches[i].test(segment)) {
             throw new TypeError('Expected all "' + token.name + '" to match "' + token.pattern + '"')
           }
 
@@ -176,7 +177,7 @@ function tokensToFunction (tokens) {
       if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
         segment = encode(String(value), token)
 
-        if (!matches[i].test(segment)) {
+        if (!skipMatch && !matches[i].test(segment)) {
           throw new TypeError('Expected "' + token.name + '" to match "' + token.pattern + '", but got "' + segment + '"')
         }
 

--- a/index.js
+++ b/index.js
@@ -137,7 +137,7 @@ function tokensToFunction (tokens) {
   return function (data, options) {
     var path = ''
     var encode = (options && options.encode) || encodeURIComponent
-    var skipMatch = (options && options.skipMatch) || false
+    var noValidate = (options && options.noValidate) || false
 
     for (var i = 0; i < tokens.length; i++) {
       var token = tokens[i]
@@ -164,7 +164,7 @@ function tokensToFunction (tokens) {
         for (var j = 0; j < value.length; j++) {
           segment = encode(value[j], token)
 
-          if (!skipMatch && !matches[i].test(segment)) {
+          if (!noValidate && !matches[i].test(segment)) {
             throw new TypeError('Expected all "' + token.name + '" to match "' + token.pattern + '"')
           }
 
@@ -177,7 +177,7 @@ function tokensToFunction (tokens) {
       if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
         segment = encode(String(value), token)
 
-        if (!skipMatch && !matches[i].test(segment)) {
+        if (!noValidate && !matches[i].test(segment)) {
           throw new TypeError('Expected "' + token.name + '" to match "' + token.pattern + '", but got "' + segment + '"')
         }
 

--- a/test.ts
+++ b/test.ts
@@ -1051,6 +1051,7 @@ var TESTS: Test[] = [
     ],
     [
       [{ test: 'abc' }, null],
+      [{ test: 'abc' }, '/abc', { skipMatch: true }],
       [{ test: '123' }, '/123']
     ]
   ],
@@ -1121,7 +1122,9 @@ var TESTS: Test[] = [
     ],
     [
       [{ route: '' }, null],
+      [{ route: '' }, '/', { skipMatch: true }],
       [{ route: '123' }, null],
+      [{ route: '123' }, '/123', { skipMatch: true }],
       [{ route: 'abc' }, '/abc']
     ]
   ],
@@ -1146,6 +1149,7 @@ var TESTS: Test[] = [
     [
       [{ route: 'this' }, '/this'],
       [{ route: 'foo' }, null],
+      [{ route: 'foo' }, '/foo', { skipMatch: true }],
       [{ route: 'that' }, '/that']
     ]
   ],
@@ -1175,7 +1179,9 @@ var TESTS: Test[] = [
       [{ path: ['abc', 'xyz'] }, '/abc/xyz'],
       [{ path: ['xyz', 'abc', 'xyz'] }, '/xyz/abc/xyz'],
       [{ path: 'abc123' }, null],
-      [{ path: 'abcxyz' }, null]
+      [{ path: 'abc123' }, '/abc123', { skipMatch: true }],
+      [{ path: 'abcxyz' }, null],
+      [{ path: 'abcxyz' }, '/abcxyz', { skipMatch: true }],
     ]
   ],
 

--- a/test.ts
+++ b/test.ts
@@ -1051,7 +1051,7 @@ var TESTS: Test[] = [
     ],
     [
       [{ test: 'abc' }, null],
-      [{ test: 'abc' }, '/abc', { skipMatch: true }],
+      [{ test: 'abc' }, '/abc', { noValidate: true }],
       [{ test: '123' }, '/123']
     ]
   ],
@@ -1122,9 +1122,9 @@ var TESTS: Test[] = [
     ],
     [
       [{ route: '' }, null],
-      [{ route: '' }, '/', { skipMatch: true }],
+      [{ route: '' }, '/', { noValidate: true }],
       [{ route: '123' }, null],
-      [{ route: '123' }, '/123', { skipMatch: true }],
+      [{ route: '123' }, '/123', { noValidate: true }],
       [{ route: 'abc' }, '/abc']
     ]
   ],
@@ -1149,7 +1149,7 @@ var TESTS: Test[] = [
     [
       [{ route: 'this' }, '/this'],
       [{ route: 'foo' }, null],
-      [{ route: 'foo' }, '/foo', { skipMatch: true }],
+      [{ route: 'foo' }, '/foo', { noValidate: true }],
       [{ route: 'that' }, '/that']
     ]
   ],
@@ -1179,9 +1179,9 @@ var TESTS: Test[] = [
       [{ path: ['abc', 'xyz'] }, '/abc/xyz'],
       [{ path: ['xyz', 'abc', 'xyz'] }, '/xyz/abc/xyz'],
       [{ path: 'abc123' }, null],
-      [{ path: 'abc123' }, '/abc123', { skipMatch: true }],
+      [{ path: 'abc123' }, '/abc123', { noValidate: true }],
       [{ path: 'abcxyz' }, null],
-      [{ path: 'abcxyz' }, '/abcxyz', { skipMatch: true }],
+      [{ path: 'abcxyz' }, '/abcxyz', { noValidate: true }],
     ]
   ],
 


### PR DESCRIPTION
I want to use this library to generate path template, like this:

```
const ptr = require('path-to-regexp');

const url = '/test/:foo(\\d+)/(.*)';
const keys = [];

const tokens = ptr.parse(url);
const regexp = ptr.tokensToRegExp(tokens, keys);
const toPath = ptr.tokensToFunction(tokens);

const data = {};
keys.forEach(({ name }) => {
  data[name] = name;
});

const path = toPath(data, {
  encode: (v) => `{${v}}`,
  noValidate: true
});

console.log(path); // => /test/{foo}/{0}
```

But it throw match error. So I add `noValidate` option.