### PR TITLE
Fix typo in README

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -110,6 +110,7 @@ regexp.exec('/')
 
 regexp.exec('/bar/baz')
 //=> [ '/bar/baz','bar/baz', index: 0, input: '/bar/baz', groups: undefined ]
+```
 
 #### Unnamed Parameters
 


### PR DESCRIPTION
The README has a typo makes Unnamed parameter part went into the code of _One or more_ code section.

Fix #183 