### PR TITLE
Add ES module version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 coverage
 components
 typings
+index.esm.js

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@ node_modules
 coverage
 components
 typings
-index.esm.js
+index.mjs

--- a/index.js
+++ b/index.js
@@ -2,10 +2,10 @@
  * Expose `pathToRegexp`.
  */
 module.exports = pathToRegexp
-module.exports.parse = parse
-module.exports.compile = compile
-module.exports.tokensToFunction = tokensToFunction
-module.exports.tokensToRegExp = tokensToRegExp
+pathToRegexp.parse = parse
+pathToRegexp.compile = compile
+pathToRegexp.tokensToFunction = tokensToFunction
+pathToRegexp.tokensToRegExp = tokensToRegExp
 
 /**
  * Default configs.

--- a/package.json
+++ b/package.json
@@ -3,12 +3,12 @@
   "description": "Express style path to RegExp utility",
   "version": "3.0.0",
   "main": "index.js",
-  "module": "index.esm.js",
+  "module": "index.mjs",
   "typings": "index.d.ts",
   "files": [
     "index.js",
     "index.d.ts",
-    "index.esm.js",
+    "index.mjs",
     "LICENSE"
   ],
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -3,14 +3,18 @@
   "description": "Express style path to RegExp utility",
   "version": "3.0.0",
   "main": "index.js",
+  "module": "index.esm.js",
   "typings": "index.d.ts",
   "files": [
     "index.js",
     "index.d.ts",
+    "index.esm.js",
     "LICENSE"
   ],
   "scripts": {
+    "create-esm": "node tools/create-esm.js",
     "lint": "standard",
+    "prepublishOnly": "npm run create-esm",
     "test-spec": "mocha --require ts-node/register -R spec --bail test.ts",
     "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require ts-node/register -R spec test.ts",
     "test": "npm run lint && npm run test-cov"

--- a/tools/create-esm.js
+++ b/tools/create-esm.js
@@ -1,0 +1,9 @@
+const fs = require('fs')
+
+const exportRegex = /module.exports\s*=\s*pathToRegexp/
+
+const cjsSource = fs.readFileSync('index.js', { encoding: 'utf8' })
+
+const esmSource = cjsSource.replace(exportRegex, 'export default pathToRegexp')
+
+fs.writeFileSync('index.esm.js', esmSource)

--- a/tools/create-esm.js
+++ b/tools/create-esm.js
@@ -6,4 +6,4 @@ const cjsSource = fs.readFileSync('index.js', { encoding: 'utf8' })
 
 const esmSource = cjsSource.replace(exportRegex, 'export default pathToRegexp')
 
-fs.writeFileSync('index.esm.js', esmSource)
+fs.writeFileSync('index.mjs', esmSource)

--- a/tools/create-esm.js
+++ b/tools/create-esm.js
@@ -4,6 +4,6 @@ const exportRegex = /module.exports\s*=\s*pathToRegexp/
 
 const cjsSource = fs.readFileSync('index.js', { encoding: 'utf8' })
 
-const esmSource = cjsSource.replace(exportRegex, 'export default pathToRegexp')
+const esmSource = cjsSource.replace(exportRegex, 'export default pathToRegexp\nexport { parse, compile, tokensToFunction, tokensToRegExp }\n')
 
 fs.writeFileSync('index.mjs', esmSource)


### PR DESCRIPTION
Fixes #174 

Add an build step to create an es module version and configure to be run before publish.

The created file `index.esm.js` is not committed since is derived from main source

Configure module entry in package.json to point to `index.esm.js`