### PR TITLE
feat: backport TokensToFunctionOptions to v1.x

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -33,6 +33,13 @@ declare namespace pathToRegexp {
     delimiter?: string;
   }
 
+  export interface TokensToFunctionOptions {
+    /**
+     * When `true` the regexp will be case sensitive. (default: `false`)
+     */
+    sensitive?: boolean;
+  }
+
   /**
    * Parse an Express-style path into an array of tokens.
    */
@@ -41,12 +48,12 @@ declare namespace pathToRegexp {
   /**
    * Transforming an Express-style path into a valid path.
    */
-  export function compile (path: string, options?: ParseOptions): PathFunction;
+  export function compile (path: string, options?: ParseOptions & TokensToFunctionOptions): PathFunction;
 
   /**
    * Transform an array of tokens into a path generator function.
    */
-  export function tokensToFunction (tokens: Token[]): PathFunction;
+  export function tokensToFunction (tokens: Token[], options?: TokensToFunctionOptions): PathFunction;
 
   /**
    * Transform an array of tokens into a matching regular expression.

--- a/index.js
+++ b/index.js
@@ -108,7 +108,7 @@ function parse (str, options) {
  * @return {!function(Object=, Object=)}
  */
 function compile (str, options) {
-  return tokensToFunction(parse(str, options))
+  return tokensToFunction(parse(str, options), options)
 }
 
 /**
@@ -138,14 +138,14 @@ function encodeAsterisk (str) {
 /**
  * Expose a method for transforming tokens into the path function.
  */
-function tokensToFunction (tokens) {
+function tokensToFunction (tokens, options) {
   // Compile all the tokens into regexps.
   var matches = new Array(tokens.length)
 
   // Compile all the patterns before compilation.
   for (var i = 0; i < tokens.length; i++) {
     if (typeof tokens[i] === 'object') {
-      matches[i] = new RegExp('^(?:' + tokens[i].pattern + ')$')
+      matches[i] = new RegExp('^(?:' + tokens[i].pattern + ')$', flags(options))
     }
   }
 
@@ -258,7 +258,7 @@ function attachKeys (re, keys) {
  * @return {string}
  */
 function flags (options) {
-  return options.sensitive ? '' : 'i'
+  return options && options.sensitive ? '' : 'i'
 }
 
 /**

--- a/test.ts
+++ b/test.ts
@@ -2238,6 +2238,60 @@ var TESTS: Test[] = [
     [
       [null, 'this is']
     ]
+  ],
+  /**
+   * Case-sensitive compile tokensToFunction params.
+   */
+  [
+    '/:test(abc)',
+    {
+      sensitive: true
+    },
+    [
+      {
+        name: 'test',
+        prefix: '/',
+        delimiter: '/',
+        optional: false,
+        repeat: false,
+        partial: false,
+        asterisk: false,
+        pattern: 'abc'
+      }
+    ],
+    [
+      ['/abc', ['/abc', 'abc']],
+      ['/ABC', null]
+    ],
+    [
+      [{ test: 'abc' }, '/abc'],
+      [{ test: 'ABC' }, null]
+    ]
+  ],
+  [
+    '/:test(abc)',
+    {
+    },
+    [
+      {
+        name: 'test',
+        prefix: '/',
+        delimiter: '/',
+        optional: false,
+        repeat: false,
+        partial: false,
+        asterisk: false,
+        pattern: 'abc'
+      }
+    ],
+    [
+      ['/abc', ['/abc', 'abc']],
+      ['/ABC', ['/ABC', 'ABC']]
+    ],
+    [
+      [{ test: 'abc' }, '/abc'],
+      [{ test: 'ABC' }, '/ABC']
+    ]
   ]
 ]
 
@@ -2322,7 +2376,7 @@ describe('path-to-regexp', function () {
       })
 
       describe(util.inspect(path), function () {
-        var re = pathToRegexp(path, opts)
+        var re = pathToRegexp(path as string, opts)
 
         // Parsing and compiling is only supported with string input.
         if (typeof path === 'string') {
@@ -2331,7 +2385,7 @@ describe('path-to-regexp', function () {
           })
 
           describe('compile', function () {
-            var toPath = pathToRegexp.compile(path)
+            var toPath = pathToRegexp.compile(path as string, opts)
 
             compileCases.forEach(function (io) {
               var input = io[0]


### PR DESCRIPTION
As requested in #191, this is a backport of that fix to the v1.x branch

This PR should be merged into a new v1.x branch based off 9c0550cc0b647a39ec7e52d0deda279e6302e547 (e.g. `git checkout -b v1.x 9c0550cc0b647a39ec7e52d0deda279e6302e547`)

Thanks :)