### PR TITLE
Use ES2015 module syntax to enable tree shaking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 coverage
 components
 typings
+index.node.js

--- a/History.md
+++ b/History.md
@@ -1,3 +1,9 @@
+4.0.0 / Unreleased
+==================
+
+  * Use ES2015 module syntax to enable tree shaking
+    (see [#197](https://github.com/pillarjs/path-to-regexp/pull/197))
+
 3.0.0 / 2019-01-13
 ==================
 

--- a/Readme.md
+++ b/Readme.md
@@ -20,7 +20,7 @@ npm install path-to-regexp --save
 ```javascript
 const pathToRegexp = require('path-to-regexp')
 
-// pathToRegexp(path, keys?, options?)
+// pathToRegexp.pathToRegexp(path, keys?, options?)
 // pathToRegexp.parse(path)
 // pathToRegexp.compile(path)
 ```
@@ -38,7 +38,7 @@ const pathToRegexp = require('path-to-regexp')
 
 ```javascript
 const keys = []
-const regexp = pathToRegexp('/foo/:bar', keys)
+const regexp = pathToRegexp.pathToRegexp('/foo/:bar', keys)
 // regexp = /^\/foo\/([^\/]+?)\/?$/i
 // keys = [{ name: 'bar', prefix: '/', delimiter: '/', optional: false, repeat: false, pattern: '[^\\/]+?' }]
 ```
@@ -54,7 +54,7 @@ The path argument is used to define parameters and populate the list of keys.
 Named parameters are defined by prefixing a colon to the parameter name (`:foo`). By default, the parameter will match until the next prefix (e.g. `[^/]+`).
 
 ```js
-const regexp = pathToRegexp('/:foo/:bar')
+const regexp = pathToRegexp.pathToRegexp('/:foo/:bar')
 // keys = [{ name: 'foo', prefix: '/', ... }, { name: 'bar', prefix: '/', ... }]
 
 regexp.exec('/test/route')
@@ -70,7 +70,7 @@ regexp.exec('/test/route')
 Parameters can be suffixed with a question mark (`?`) to make the parameter optional.
 
 ```js
-const regexp = pathToRegexp('/:foo/:bar?')
+const regexp = pathToRegexp.pathToRegexp('/:foo/:bar?')
 // keys = [{ name: 'foo', ... }, { name: 'bar', delimiter: '/', optional: true, repeat: false }]
 
 regexp.exec('/test')
@@ -87,7 +87,7 @@ regexp.exec('/test/route')
 Parameters can be suffixed with an asterisk (`*`) to denote a zero or more parameter matches. The prefix is used for each match.
 
 ```js
-const regexp = pathToRegexp('/:foo*')
+const regexp = pathToRegexp.pathToRegexp('/:foo*')
 // keys = [{ name: 'foo', delimiter: '/', optional: true, repeat: true }]
 
 regexp.exec('/')
@@ -102,7 +102,7 @@ regexp.exec('/bar/baz')
 Parameters can be suffixed with a plus sign (`+`) to denote a one or more parameter matches. The prefix is used for each match.
 
 ```js
-const regexp = pathToRegexp('/:foo+')
+const regexp = pathToRegexp.pathToRegexp('/:foo+')
 // keys = [{ name: 'foo', delimiter: '/', optional: false, repeat: true }]
 
 regexp.exec('/')
@@ -117,7 +117,7 @@ regexp.exec('/bar/baz')
 It is possible to write an unnamed parameter that only consists of a matching group. It works the same as a named parameter, except it will be numerically indexed.
 
 ```js
-const regexp = pathToRegexp('/:foo/(.*)')
+const regexp = pathToRegexp.pathToRegexp('/:foo/(.*)')
 // keys = [{ name: 'foo', ... }, { name: 0, ... }]
 
 regexp.exec('/test/route')
@@ -129,7 +129,7 @@ regexp.exec('/test/route')
 All parameters can have a custom regexp, which overrides the default match (`[^/]+`). For example, you can match digits or names in a path:
 
 ```js
-const regexpNumbers = pathToRegexp('/icon-:foo(\\d+).png')
+const regexpNumbers = pathToRegexp.pathToRegexp('/icon-:foo(\\d+).png')
 // keys = [{ name: 'foo', ... }]
 
 regexpNumbers.exec('/icon-123.png')
@@ -138,7 +138,7 @@ regexpNumbers.exec('/icon-123.png')
 regexpNumbers.exec('/icon-abc.png')
 //=> null
 
-const regexpWord = pathToRegexp('/(user|u)')
+const regexpWord = pathToRegexp.pathToRegexp('/(user|u)')
 // keys = [{ name: 0, ... }]
 
 regexpWord.exec('/u')

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,94 +1,90 @@
-declare function pathToRegexp (path: pathToRegexp.Path, keys?: pathToRegexp.Key[], options?: pathToRegexp.RegExpOptions & pathToRegexp.ParseOptions): RegExp;
+export function pathToRegexp (path: Path, keys?: Key[], options?: RegExpOptions & ParseOptions): RegExp;
 
-declare namespace pathToRegexp {
-  export interface RegExpOptions {
-    /**
-     * When `true` the regexp will be case sensitive. (default: `false`)
-     */
-    sensitive?: boolean;
-    /**
-     * When `true` the regexp allows an optional trailing delimiter to match. (default: `false`)
-     */
-    strict?: boolean;
-    /**
-     * When `true` the regexp will match to the end of the string. (default: `true`)
-     */
-    end?: boolean;
-    /**
-     * When `true` the regexp will match from the beginning of the string. (default: `true`)
-     */
-    start?: boolean;
-    /**
-     * Sets the final character for non-ending optimistic matches. (default: `/`)
-     */
-    delimiter?: string;
-    /**
-     * List of characters that can also be "end" characters.
-     */
-    endsWith?: string | string[];
-    /**
-     * List of characters to consider delimiters when parsing. (default: `undefined`, any character)
-     */
-    whitelist?: string | string[];
-  }
-
-  export interface ParseOptions {
-    /**
-     * Set the default delimiter for repeat parameters. (default: `'/'`)
-     */
-    delimiter?: string;
-  }
-
-  export interface TokensToFunctionOptions {
-    /**
-     * When `true` the regexp will be case sensitive. (default: `false`)
-     */
-    sensitive?: boolean;
-  }
-
+export interface RegExpOptions {
   /**
-   * Parse an Express-style path into an array of tokens.
+   * When `true` the regexp will be case sensitive. (default: `false`)
    */
-  export function parse (path: string, options?: ParseOptions): Token[];
-
+  sensitive?: boolean;
   /**
-   * Transforming an Express-style path into a valid path.
+   * When `true` the regexp allows an optional trailing delimiter to match. (default: `false`)
    */
-  export function compile <P extends object = object> (path: string, options?: ParseOptions & TokensToFunctionOptions): PathFunction<P>;
-
+  strict?: boolean;
   /**
-   * Transform an array of tokens into a path generator function.
+   * When `true` the regexp will match to the end of the string. (default: `true`)
    */
-  export function tokensToFunction <P extends object = object> (tokens: Token[], options?: TokensToFunctionOptions): PathFunction<P>;
-
+  end?: boolean;
   /**
-   * Transform an array of tokens into a matching regular expression.
+   * When `true` the regexp will match from the beginning of the string. (default: `true`)
    */
-  export function tokensToRegExp (tokens: Token[], keys?: Key[], options?: RegExpOptions): RegExp;
-
-  export interface Key {
-    name: string | number;
-    prefix: string;
-    delimiter: string;
-    optional: boolean;
-    repeat: boolean;
-    pattern: string;
-  }
-
-  interface PathFunctionOptions {
-    /**
-     * Function for encoding input strings for output.
-     */
-    encode?: (value: string, token: Key) => string;
-    /**
-     * When `false` the function can produce an invalid (unmatched) path. (default: `true`)
-     */
-    validate?: boolean;
-  }
-
-  export type Token = string | Key;
-  export type Path = string | RegExp | Array<string | RegExp>;
-  export type PathFunction <P extends object = object> = (data?: P, options?: PathFunctionOptions) => string;
+  start?: boolean;
+  /**
+   * Sets the final character for non-ending optimistic matches. (default: `/`)
+   */
+  delimiter?: string;
+  /**
+   * List of characters that can also be "end" characters.
+   */
+  endsWith?: string | string[];
+  /**
+   * List of characters to consider delimiters when parsing. (default: `undefined`, any character)
+   */
+  whitelist?: string | string[];
 }
 
-export = pathToRegexp;
+export interface ParseOptions {
+  /**
+   * Set the default delimiter for repeat parameters. (default: `'/'`)
+   */
+  delimiter?: string;
+}
+
+export interface TokensToFunctionOptions {
+  /**
+   * When `true` the regexp will be case sensitive. (default: `false`)
+   */
+  sensitive?: boolean;
+}
+
+/**
+ * Parse an Express-style path into an array of tokens.
+ */
+export function parse (path: string, options?: ParseOptions): Token[];
+
+/**
+ * Transforming an Express-style path into a valid path.
+ */
+export function compile <P extends object = object> (path: string, options?: ParseOptions & TokensToFunctionOptions): PathFunction<P>;
+
+/**
+ * Transform an array of tokens into a path generator function.
+ */
+export function tokensToFunction <P extends object = object> (tokens: Token[], options?: TokensToFunctionOptions): PathFunction<P>;
+
+/**
+ * Transform an array of tokens into a matching regular expression.
+ */
+export function tokensToRegExp (tokens: Token[], keys?: Key[], options?: RegExpOptions): RegExp;
+
+export interface Key {
+  name: string | number;
+  prefix: string;
+  delimiter: string;
+  optional: boolean;
+  repeat: boolean;
+  pattern: string;
+}
+
+export interface PathFunctionOptions {
+  /**
+   * Function for encoding input strings for output.
+   */
+  encode?: (value: string, token: Key) => string;
+  /**
+   * When `false` the function can produce an invalid (unmatched) path. (default: `true`)
+   */
+  validate?: boolean;
+}
+
+export type Token = string | Key;
+export type Path = string | RegExp | Array<string | RegExp>;
+export type PathFunction <P extends object = object> = (data?: P, options?: PathFunctionOptions) => string;

--- a/index.js
+++ b/index.js
@@ -1,11 +1,11 @@
 /**
  * Expose `pathToRegexp`.
  */
-module.exports = pathToRegexp
-module.exports.parse = parse
-module.exports.compile = compile
-module.exports.tokensToFunction = tokensToFunction
-module.exports.tokensToRegExp = tokensToRegExp
+export { pathToRegexp }
+export { parse }
+export { compile }
+export { tokensToFunction }
+export { tokensToRegExp }
 
 /**
  * Default configs.

--- a/package-lock.json
+++ b/package-lock.json
@@ -135,6 +135,12 @@
       "integrity": "sha512-OuYBlXWHYthxIudMXMeQr92f6D97YoT9CUYCRb0BEP4OavC95jNcczjjr4Ob3H5E1IqlWqwj+leUZPSeth27Qw==",
       "dev": true
     },
+    "@types/estree": {
+      "version": "0.0.39",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
+      "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
+      "dev": true
+    },
     "@types/mocha": {
       "version": "5.2.5",
       "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-5.2.5.tgz",
@@ -2766,6 +2772,25 @@
             "once": "^1.3.0",
             "path-is-absolute": "^1.0.0"
           }
+        }
+      }
+    },
+    "rollup": {
+      "version": "1.25.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-1.25.2.tgz",
+      "integrity": "sha512-+7z6Wab/L45QCPcfpuTZKwKiB0tynj05s/+s2U3F2Bi7rOLPr9UcjUwO7/xpjlPNXA/hwnth6jBExFRGyf3tMg==",
+      "dev": true,
+      "requires": {
+        "@types/estree": "*",
+        "@types/node": "*",
+        "acorn": "^7.1.0"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.0.tgz",
+          "integrity": "sha512-kL5CuoXA/dgxlBbVrflsflzQ3PAas7RYZB52NOm/6839iVYJgKMJ3cQJD+t2i5+qFa8h3MDpEOJiS64E8JLnSQ==",
+          "dev": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -2,10 +2,12 @@
   "name": "path-to-regexp",
   "description": "Express style path to RegExp utility",
   "version": "3.1.0",
-  "main": "index.js",
+  "main": "index.node.js",
+  "module": "index.js",
   "typings": "index.d.ts",
   "files": [
     "index.js",
+    "index.node.js",
     "index.d.ts",
     "LICENSE"
   ],
@@ -14,7 +16,11 @@
     "test-spec": "mocha --require ts-node/register -R spec --bail test.ts",
     "test-cov": "nyc --reporter=lcov mocha -- --require ts-node/register -R spec test.ts",
     "coverage": "nyc report --reporter=text-lcov",
-    "test": "npm run lint && npm run test-cov"
+    "test": "npm run lint && npm run test-cov",
+    "build": "rollup --format cjs --input index.js --file index.node.js",
+    "pretest-spec": "npm run build",
+    "pretest-cov": "npm run build",
+    "prepublishOnly": "npm run build"
   },
   "keywords": [
     "express",
@@ -39,6 +45,7 @@
     "chai": "^4.1.1",
     "mocha": "^6.2.0",
     "nyc": "^14.1.1",
+    "rollup": "^1.25.2",
     "standard": "^14.1.0",
     "ts-node": "^8.3.0",
     "typescript": "^3.0.1"

--- a/test.ts
+++ b/test.ts
@@ -2,7 +2,7 @@
 
 import util = require('util')
 import chai = require('chai')
-import pathToRegexp = require('./index')
+import pathToRegexp = require('./')
 
 const expect = chai.expect
 
@@ -2722,22 +2722,22 @@ describe('path-to-regexp', function () {
 
   describe('arguments', function () {
     it('should work without different call combinations', function () {
-      pathToRegexp('/test')
-      pathToRegexp('/test', [])
-      pathToRegexp('/test', undefined, {})
+      pathToRegexp.pathToRegexp('/test')
+      pathToRegexp.pathToRegexp('/test', [])
+      pathToRegexp.pathToRegexp('/test', undefined, {})
 
-      pathToRegexp(/^\/test/)
-      pathToRegexp(/^\/test/, [])
-      pathToRegexp(/^\/test/, null, {})
+      pathToRegexp.pathToRegexp(/^\/test/)
+      pathToRegexp.pathToRegexp(/^\/test/, [])
+      pathToRegexp.pathToRegexp(/^\/test/, null, {})
 
-      pathToRegexp(['/a', '/b'])
-      pathToRegexp(['/a', '/b'], [])
-      pathToRegexp(['/a', '/b'], null, {})
+      pathToRegexp.pathToRegexp(['/a', '/b'])
+      pathToRegexp.pathToRegexp(['/a', '/b'], [])
+      pathToRegexp.pathToRegexp(['/a', '/b'], null, {})
     })
 
     it('should accept an array of keys as the second argument', function () {
       var keys = []
-      var re = pathToRegexp(TEST_PATH, keys, { end: false })
+      var re = pathToRegexp.pathToRegexp(TEST_PATH, keys, { end: false })
 
       expect(keys).to.deep.equal([TEST_PARAM])
       expect(exec(re, '/user/123/show')).to.deep.equal(['/user/123', '123'])
@@ -2770,7 +2770,7 @@ describe('path-to-regexp', function () {
 
       describe(util.inspect(path), function () {
         var keys = []
-        var re = pathToRegexp(path, keys, opts)
+        var re = pathToRegexp.pathToRegexp(path, keys, opts)
 
         // Parsing and compiling is only supported with string input.
         if (typeof path === 'string') {


### PR DESCRIPTION
This PR allow users to use `path-to-regexp` with all the benefits of ES Modules.

**How to use:**

```js
import * as pathToRegexp from 'path-to-regexp'

// pathToRegexp.pathToRegexp(path, keys?, options?)
// pathToRegexp.parse(path)
// pathToRegexp.compile(path)
```
or
```js
import { pathToRegexp, parse, compile } from 'path-to-regexp'

// pathToRegexp(path, keys?, options?)
// parse(path)
// compile(path)
```

or

```js
const pathToRegexp = require('path-to-regexp')

// pathToRegexp.pathToRegexp(path, keys?, options?)
// pathToRegexp.parse(path)
// pathToRegexp.compile(path)
```
or
```js
const { pathToRegexp, parse, compile } = require('path-to-regexp')

// pathToRegexp(path, keys?, options?)
// parse(path)
// compile(path)
```

**How to migrate from v3 to v4:**

```diff
  const pathToRegexp = require('path-to-regexp')

- // pathToRegexp(path, keys?, options?)
+ // pathToRegexp.pathToRegexp(path, keys?, options?)
  // pathToRegexp.parse(path)
  // pathToRegexp.compile(path)
```

**Why:**

It allows to make our client-side bundles smaller.
For example see how ESM version affects [`universal-router`](https://github.com/kriasoft/universal-router) package:

| File Size (bytes) | Before | After | Saved |
|-|-|-|-|
| universal-router.min.js.gz | 2490 | 2069 | 17% |
| universal-router.min.js | 5598 | 4436 | 21% |

---

Also it allows to use the package in modern browsers without any transformations (no compilation or build step required) :tada:
```js
<script type="module">
  import * as pathToRegexp from 'https://unpkg.com/path-to-regexp?module'

  // pathToRegexp.pathToRegexp(path, keys?, options?)
  // pathToRegexp.parse(path)
  // pathToRegexp.compile(path)
</script>
```