### PR TITLE
Add documentation for modified param with custom regexp

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -152,6 +152,21 @@ regexpWord.exec("/users");
 
 **Tip:** Backslashes need to be escaped with another backslash in JavaScript strings.
 
+##### Modified Custom Matching Parameters
+
+When using a modifier whith a custom regexp, the modifier is added after the regexp:
+
+```js
+const regexp = pathToRegexp("/:foo(\\d+)?");
+// keys = [{ name: 'foo', delimiter: '/', optional: true, repeat: false }]
+
+regexp.exec("/");
+//=> [ '/', undefined, index: 0, input: '/', groups: undefined ]
+
+regexp.exec("/123");
+//=> [ '/123', '123', index: 0, input: '/123', groups: undefined ]
+```
+
 ### Match
 
 The `match` function will return a function for transforming paths into parameters:


### PR DESCRIPTION
It is not quite clear where the modifier goes, when modifying a parameter with a custom regexp. Took me a while to figure it out. This should clear this up.