### PR TITLE
Ignore .spec.ts files when compiling

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,5 +13,6 @@
     "sourceMap": true,
     "inlineSources": true
   },
-  "include": ["src/**/*"]
+  "include": ["src/**/*"],
+  "exclude": ["src/**/*.spec.ts"]
 }


### PR DESCRIPTION
Relates to #219 

Assuming the `.spec.ts` file are not intended to be part of the distribution, they should be ignored when compiling.