### PR TITLE
[DO NOT MERGE] global route match bug demo

### DIFF
--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -64,6 +64,21 @@ const TESTS: Test[] = [
     ],
     [[null, "/test/"]]
   ],
+  [
+    "/test/*",
+    undefined,
+    ["/test"],
+    [
+      ["/test", ["/test"], { path: "/test", index: 0, params: {} }],
+      ["/route", null, false],
+      ["/test/route", null, false],
+      ["/test/", ["/test/"], { path: "/test/", index: 0, params: {} }]
+    ],
+    [
+      [null, "/test"],
+      [{}, "/test"]
+    ]
+  ],
 
   /**
    * Case-sensitive paths.


### PR DESCRIPTION
[Do not merge] Only opening a PR here for the CI tests to demostrate the bug.

Global route match syntax cause a parsing error. 

For example, when using the route:
```ts
  app.get('/test/*', (req, res) => {
    res.sendStatus(200);
  });
```

The parsing error is thrown:
```
  ● path-to-regexp › rules › '/test/*' › encountered a declaration exception

    TypeError: Unexpected MODIFIER at 6, expected END

      155 |     if (value !== undefined) return value;
      156 |     const { type: nextType, index } = tokens[i];
    > 157 |     throw new TypeError(`Unexpected ${nextType} at ${index}, expected ${type}`);
          |           ^
      158 |   };
      159 | 
      160 |   const consumeText = (): string => {

      at mustConsume (src/index.ts:157:11)
      at parse (src/index.ts:228:5)
      at stringToRegexp (src/index.ts:495:25)
      at Object.pathToRegexp (src/index.ts:617:10)
      at Suite.<anonymous> (src/index.spec.ts:2804:33)
      at src/index.spec.ts:2802:7
          at Array.forEach (<anonymous>)
      at Suite.<anonymous> (src/index.spec.ts:2799:11)
      at Suite.<anonymous> (src/index.spec.ts:2798:3)
      at Object.<anonymous> (src/index.spec.ts:2705:1)
```

See Express documentation for global/wildcard route definitions here:
https://expressjs.com/en/4x/api.html#router.methods