### PR TITLE
Fix the invalid matching of the ":name*" parameter

### DIFF
--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -2611,6 +2611,21 @@ const TESTS: Test[] = [
     [["foobar", ["foobar", "foobar"]]],
     [[{ name: "foobar" }, "foobar"]],
   ],
+  [
+    ":name+",
+    undefined,
+    [
+      {
+        name: "name",
+        prefix: "",
+        suffix: "",
+        modifier: "+",
+        pattern: "[^\\/#\\?]+?",
+      },
+    ],
+    [["foobar", ["foobar", "foobar"]]],
+    [[{ name: "foobar" }, "foobar"]],
+  ],
 ];
 
 /**

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -2593,6 +2593,24 @@ const TESTS: Test[] = [
       [{ foo: "#" }, null],
     ],
   ],
+  /**
+   * https://github.com/pillarjs/path-to-regexp/issues/260
+   */
+  [
+    ":name*",
+    undefined,
+    [
+      {
+        name: "name",
+        prefix: "",
+        suffix: "",
+        modifier: "*",
+        pattern: "[^\\/#\\?]+?",
+      },
+    ],
+    [["foobar", ["foobar", "foobar"]]],
+    [[{ name: "foobar" }, "foobar"]],
+  ],
 ];
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -563,7 +563,7 @@ export function tokensToRegexp(
             route += `(?:${prefix}(${token.pattern})${suffix})${token.modifier}`;
           }
         } else {
-          if (token.modifier === "*") {
+          if (token.modifier === "+" || token.modifier === "*") {
             route += `((?:${token.pattern})${token.modifier})`;
           } else {
             route += `(${token.pattern})${token.modifier}`;

--- a/src/index.ts
+++ b/src/index.ts
@@ -563,7 +563,11 @@ export function tokensToRegexp(
             route += `(?:${prefix}(${token.pattern})${suffix})${token.modifier}`;
           }
         } else {
-          route += `(${token.pattern})${token.modifier}`;
+          if (token.modifier === "*") {
+            route += `((?:${token.pattern})${token.modifier})`;
+          } else {
+            route += `(${token.pattern})${token.modifier}`;
+          }
         }
       } else {
         route += `(?:${prefix}${suffix})${token.modifier}`;


### PR DESCRIPTION
## GitHub

- Fixes #260 

## Changes

- Adds a test case for matching/parsing/compiling the `:name*` problematic parameter pattern.