### PR TITLE
fix: error in Readme.md 

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -82,7 +82,7 @@ re.exec('/test')
 //=> ['/test', 'test', undefined]
 
 re.exec('/test/route')
-//=> ['/test', 'test', 'route']
+//=> ['/test/route', 'test', 'route']
 ```
 
 ##### Zero or more


### PR DESCRIPTION
Fix an error in the result of `re.exec('/test/route')`.

Since this version of `path-to-regexp` is still in use in react-router@5.x, I think it worthwhile to fix it.