### PR TITLE
Add back `keys` property to regex

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -381,6 +381,13 @@ export function match<P extends object = object>(
   return regexpToFunction<P>(re, keys, options);
 }
 
+export interface RegExpWithKeys extends RegExp {
+  /**
+   * Optional property that includes key metadata corresponding to this regex.
+   */
+  keys?: Key[];
+}
+
 /**
  * Create a path match function from `path-to-regexp` output.
  */
@@ -479,9 +486,14 @@ function arrayToRegexp(
   paths: Array<string | RegExp>,
   keys?: Key[],
   options?: TokensToRegexpOptions & ParseOptions
-): RegExp {
+): RegExpWithKeys {
   const parts = paths.map((path) => pathToRegexp(path, keys, options).source);
-  return new RegExp(`(?:${parts.join("|")})`, flags(options));
+  const re: RegExpWithKeys = new RegExp(
+    `(?:${parts.join("|")})`,
+    flags(options)
+  );
+  re.keys = keys;
+  return re;
 }
 
 /**
@@ -533,7 +545,7 @@ export function tokensToRegexp(
   tokens: Token[],
   keys?: Key[],
   options: TokensToRegexpOptions = {}
-) {
+): RegExpWithKeys {
   const {
     strict = false,
     start = true,
@@ -596,7 +608,10 @@ export function tokensToRegexp(
     }
   }
 
-  return new RegExp(route, flags(options));
+  const re: RegExpWithKeys = new RegExp(route, flags(options));
+  re.keys = keys;
+
+  return re;
 }
 
 /**


### PR DESCRIPTION
See issue #236

The returned regex object from `pathToRegex` used to include the modified
keys array as a `keys` property in v1.7.0. The current API is not entirely
ideal, since a keys array must be passed, we could instead use a more
functional API without mutation.

In the future this should be changed that no array needs to be passed to `pathToRegex`, 
adding it as a property this way is done to maintain backwards compatibility.