### PR TITLE
Add support for named matching groups.

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@ module.exports = pathtoRegexp;
  * Match matching groups in a regular expression.
  */
 var MATCHING_GROUP_REGEXP = /\((?!\?)/g;
+var MATCHING_NAMED_GROUP_REGEXP = /\(\?<(.+?)>/g;
 
 /**
  * Normalize the given path string,
@@ -41,6 +42,13 @@ function pathtoRegexp(path, keys, options) {
     while (m = MATCHING_GROUP_REGEXP.exec(path.source)) {
       keys.push({
         name: name++,
+        optional: false,
+        offset: m.index
+      });
+    }
+    while (m = MATCHING_NAMED_GROUP_REGEXP.exec(path.source)) {
+      keys.push({
+        name: m[1],
         optional: false,
         offset: m.index
       });

--- a/index.js
+++ b/index.js
@@ -7,8 +7,7 @@ module.exports = pathtoRegexp;
 /**
  * Match matching groups in a regular expression.
  */
-var MATCHING_GROUP_REGEXP = /\((?!\?)/g;
-var MATCHING_NAMED_GROUP_REGEXP = /\(\?<(.+?)>/g;
+var MATCHING_GROUP_REGEXP = /\((?:\?<(.*?)>)?(?!\?)/g;
 
 /**
  * Normalize the given path string,
@@ -41,14 +40,7 @@ function pathtoRegexp(path, keys, options) {
   if (path instanceof RegExp) {
     while (m = MATCHING_GROUP_REGEXP.exec(path.source)) {
       keys.push({
-        name: name++,
-        optional: false,
-        offset: m.index
-      });
-    }
-    while (m = MATCHING_NAMED_GROUP_REGEXP.exec(path.source)) {
-      keys.push({
-        name: m[1],
+        name: m[1] || name++,
         optional: false,
         offset: m.index
       });

--- a/test.js
+++ b/test.js
@@ -735,9 +735,9 @@ describe('path-to-regexp', function () {
       assert.equal(params.length, 3);
       assert.equal(params[0].name, 0);
       assert.equal(params[0].optional, false);
-      assert.equal(params[1].name, 1);
+      assert.equal(params[1].name, 'foo');
       assert.equal(params[1].optional, false);
-      assert.equal(params[2].name, 'foo');
+      assert.equal(params[2].name, 1);
       assert.equal(params[2].optional, false);
 
       m = re.exec('/foo/bar/baz');

--- a/test.js
+++ b/test.js
@@ -574,6 +574,7 @@ describe('path-to-regexp', function () {
     it('should match trailing slashing in non-ending strict mode', function () {
       var params = [];
       var re = pathToRegExp('/route/', params, { end: false, strict: true });
+      var m;
 
       assert.equal(params.length, 0);
 
@@ -600,6 +601,7 @@ describe('path-to-regexp', function () {
     it('should not match trailing slashes in non-ending strict mode', function () {
       var params = [];
       var re = pathToRegExp('/route', params, { end: false, strict: true });
+      var m;
 
       assert.equal(params.length, 0);
 
@@ -617,6 +619,7 @@ describe('path-to-regexp', function () {
     it('should match text after an express param', function () {
       var params = [];
       var re = pathToRegExp('/(:test)route', params);
+      var m;
 
       assert.equal(params.length, 1);
       assert.equal(params[0].name, 'test');
@@ -723,6 +726,28 @@ describe('path-to-regexp', function () {
       assert.equal(m[0], '/route');
       assert.equal(m[1], '/route');
     });
+
+    it('should pull out matching named groups', function () {
+      var params = [];
+      var re = pathToRegExp(/\/(.*)\/(?<foo>.*)\/(.*)/, params);
+      var m;
+
+      assert.equal(params.length, 3);
+      assert.equal(params[0].name, 0);
+      assert.equal(params[0].optional, false);
+      assert.equal(params[1].name, 1);
+      assert.equal(params[1].optional, false);
+      assert.equal(params[2].name, 'foo');
+      assert.equal(params[2].optional, false);
+
+      m = re.exec('/foo/bar/baz');
+
+      assert.equal(m.length, 4);
+      assert.equal(m[0], '/foo/bar/baz');
+      assert.equal(m[1], 'foo');
+      assert.equal(m[2], 'bar');
+      assert.equal(m[3], 'baz');
+    })
   });
 
   describe('arrays', function () {


### PR DESCRIPTION
Express 4.x crashes when using named capturing group in regexp (see https://github.com/expressjs/express/issues/4277 ).
As far as I know, this feature have been added in newer version of path-to-regexp. It seems that it will land in Express 5.
This change aims to add the feature in current version of Express, which still uses path-to-regexp 0.1.x.