### PR TITLE
Explicit prefix and suffix modifiers

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -16,59 +16,54 @@ npm install path-to-regexp --save
 
 ## Usage
 
-```javascript
+```js
 const { pathToRegexp, match, parse, compile } = require("path-to-regexp");
 
-// pathToRegexp(path, keys?, options?)
-// match(path)
-// parse(path)
-// compile(path)
+// pathToRegexp(path, options?)
+// match(path, options?)
+// parse(path, options?)
+// compile(path, options?)
 ```
 
 ### Path to regexp
 
-The `pathToRegexp` function will return a regular expression object based on the provided `path` argument. It accepts the following arguments:
+The `pathToRegexp` function returns a regular expression with `keys` as a property. It accepts the following arguments:
 
-- **path** A string, array of strings, or a regular expression.
-- **keys** _(optional)_ An array to populate with keys found in the path.
+- **path** A string.
 - **options** _(optional)_
-  - **sensitive** When `true` the regexp will be case sensitive. (default: `false`)
-  - **strict** When `true` the regexp won't allow an optional trailing delimiter to match. (default: `false`)
-  - **end** When `true` the regexp will match to the end of the string. (default: `true`)
-  - **start** When `true` the regexp will match from the beginning of the string. (default: `true`)
-  - **delimiter** The default delimiter for segments, e.g. `[^/#?]` for `:named` patterns. (default: `'/#?'`)
-  - **endsWith** Optional character, or list of characters, to treat as "end" characters.
-  - **encode** A function to encode strings before inserting into `RegExp`. (default: `x => x`)
-  - **prefixes** List of characters to automatically consider prefixes when parsing. (default: `./`)
+  - **sensitive** Regexp will be case sensitive. (default: `false`)
+  - **trailing** Regexp allows an optional trailing delimiter to match. (default: `true`)
+  - **end** Match to the end of the string. (default: `true`)
+  - **start** Match from the beginning of the string. (default: `true`)
+  - **loose** Allow the delimiter to be repeated an arbitrary number of times. (default: `true`)
+  - **delimiter** The default delimiter for segments, e.g. `[^/]` for `:named` parameters. (default: `'/'`)
+  - **encodePath** A function to encode strings before inserting into `RegExp`. (default: `x => x`, recommended: [`encodeurl`](https://github.com/pillarjs/encodeurl))
 
-```javascript
-const keys = [];
-const regexp = pathToRegexp("/foo/:bar", keys);
-// regexp = /^\/foo(?:\/([^\/#\?]+?))[\/#\?]?$/i
-// keys = [{ name: 'bar', prefix: '/', suffix: '', pattern: '[^\\/#\\?]+?', modifier: '' }]
+```js
+const regexp = pathToRegexp("/foo/:bar");
+// regexp = /^\/+foo(?:\/+([^\/]+?))(?:\/+)?$/i
+// keys = [{ name: 'bar', prefix: '', suffix: '', pattern: '', modifier: '' }]
 ```
 
-**Please note:** The `RegExp` returned by `path-to-regexp` is intended for ordered data (e.g. pathnames, hostnames). It can not handle arbitrarily ordered data (e.g. query strings, URL fragments, JSON, etc). When using paths that contain query strings, you need to escape the question mark (`?`) to ensure it does not flag the parameter as [optional](#optional).
+**Please note:** The `RegExp` returned by `path-to-regexp` is intended for ordered data (e.g. pathnames, hostnames). It can not handle arbitrarily ordered data (e.g. query strings, URL fragments, JSON, etc).
 
 ### Parameters
 
 The path argument is used to define parameters and populate keys.
 
-#### Named Parameters
+#### Named parameters
 
-Named parameters are defined by prefixing a colon to the parameter name (`:foo`).
+Named parameters are defined by prefixing a colon to the parameter name (`:foo`). Parameter names can use any valid unicode identifier characters (similar to JavaScript).
 
 ```js
 const regexp = pathToRegexp("/:foo/:bar");
-// keys = [{ name: 'foo', prefix: '/', ... }, { name: 'bar', prefix: '/', ... }]
+// keys = [{ name: 'foo', ... }, { name: 'bar', ... }]
 
 regexp.exec("/test/route");
-//=> [ '/test/route', 'test', 'route', index: 0, input: '/test/route', groups: undefined ]
+//=> [ '/test/route', 'test', 'route', index: 0 ]
 ```
 
-**Please note:** Parameter names must use "word characters" (`[A-Za-z0-9_]`).
-
-##### Custom Matching Parameters
+##### Custom matching parameters
 
 Parameters can have a custom regexp, which overrides the default match (`[^/]+`). For example, you can match digits or names in a path:
 
@@ -94,12 +89,24 @@ regexpWord.exec("/users");
 
 **Tip:** Backslashes need to be escaped with another backslash in JavaScript strings.
 
-##### Custom Prefix and Suffix
+#### Unnamed parameters
+
+It is possible to define a parameter without a name. The name will be numerically indexed:
+
+```js
+const regexp = pathToRegexp("/:foo/(.*)");
+// keys = [{ name: 'foo', ... }, { name: '0', ... }]
+
+regexp.exec("/test/route");
+//=> [ '/test/route', 'test', 'route', index: 0 ]
+```
+
+##### Custom prefix and suffix
 
 Parameters can be wrapped in `{}` to create custom prefixes or suffixes for your segment:
 
 ```js
-const regexp = pathToRegexp("/:attr1?{-:attr2}?{-:attr3}?");
+const regexp = pathToRegexp("{/:attr1}?{-:attr2}?{-:attr3}?");
 
 regexp.exec("/test");
 // => ['/test', 'test', undefined, undefined]
@@ -108,50 +115,23 @@ regexp.exec("/test-test");
 // => ['/test', 'test', 'test', undefined]
 ```
 
-#### Unnamed Parameters
-
-It is possible to write an unnamed parameter that only consists of a regexp. It works the same the named parameter, except it will be numerically indexed:
-
-```js
-const regexp = pathToRegexp("/:foo/(.*)");
-// keys = [{ name: 'foo', ... }, { name: 0, ... }]
-
-regexp.exec("/test/route");
-//=> [ '/test/route', 'test', 'route', index: 0, input: '/test/route', groups: undefined ]
-```
-
 #### Modifiers
 
-Modifiers must be placed after the parameter (e.g. `/:foo?`, `/(test)?`, `/:foo(test)?`, or `{-:foo(test)}?`).
+Modifiers are used after parameters with custom prefixes and suffixes (`{}`).
 
 ##### Optional
 
 Parameters can be suffixed with a question mark (`?`) to make the parameter optional.
 
 ```js
-const regexp = pathToRegexp("/:foo/:bar?");
+const regexp = pathToRegexp("/:foo{/:bar}?");
 // keys = [{ name: 'foo', ... }, { name: 'bar', prefix: '/', modifier: '?' }]
 
 regexp.exec("/test");
-//=> [ '/test', 'test', undefined, index: 0, input: '/test', groups: undefined ]
+//=> [ '/test', 'test', undefined, index: 0 ]
 
 regexp.exec("/test/route");
-//=> [ '/test/route', 'test', 'route', index: 0, input: '/test/route', groups: undefined ]
-```
-
-**Tip:** The prefix is also optional, escape the prefix `\/` to make it required.
-
-When dealing with query strings, escape the question mark (`?`) so it doesn't mark the parameter as optional. Handling unordered data is outside the scope of this library.
-
-```js
-const regexp = pathToRegexp("/search/:tableName\\?useIndex=true&term=amazing");
-
-regexp.exec("/search/people?useIndex=true&term=amazing");
-//=> [ '/search/people?useIndex=true&term=amazing', 'people', index: 0, input: '/search/people?useIndex=true&term=amazing', groups: undefined ]
-
-// This library does not handle query strings in different orders
-regexp.exec("/search/people?term=amazing&useIndex=true");
-//=> null
+//=> [ '/test/route', 'test', 'route', index: 0 ]
 ```
 
 ##### Zero or more
@@ -159,14 +139,14 @@ regexp.exec("/search/people?term=amazing&useIndex=true");
 Parameters can be suffixed with an asterisk (`*`) to denote a zero or more parameter matches.
 
 ```js
-const regexp = pathToRegexp("/:foo*");
+const regexp = pathToRegexp("{/:foo}*");
 // keys = [{ name: 'foo', prefix: '/', modifier: '*' }]
 
-regexp.exec("/");
-//=> [ '/', undefined, index: 0, input: '/', groups: undefined ]
+regexp.exec("/foo");
+//=> [ '/foo', "foo", index: 0 ]
 
 regexp.exec("/bar/baz");
-//=> [ '/bar/baz', 'bar/baz', index: 0, input: '/bar/baz', groups: undefined ]
+//=> [ '/bar/baz', 'bar/baz', index: 0 ]
 ```
 
 ##### One or more
@@ -174,19 +154,38 @@ regexp.exec("/bar/baz");
 Parameters can be suffixed with a plus sign (`+`) to denote a one or more parameter matches.
 
 ```js
-const regexp = pathToRegexp("/:foo+");
+const regexp = pathToRegexp("{/:foo}+");
 // keys = [{ name: 'foo', prefix: '/', modifier: '+' }]
 
 regexp.exec("/");
 //=> null
 
 regexp.exec("/bar/baz");
-//=> [ '/bar/baz','bar/baz', index: 0, input: '/bar/baz', groups: undefined ]
+//=> [ '/bar/baz', 'bar/baz', index: 0 ]
+```
+
+#### Wildcard
+
+A wildcard can also be used. It is roughly equivalent to `(.*)` except when decoding in `match` below it splits on the delimiter.
+
+```js
+const regexp = pathToRegexp("/*");
+// keys = [{ name: '0', pattern: '[^\\/]*', modifier: '*' }]
+
+regexp.exec("/");
+//=> [ '/', '', index: 0 ]
+
+regexp.exec("/bar/baz");
+//=> [ '/bar/baz', 'bar/baz', index: 0 ]
 ```
 
 ### Match
 
-The `match` function will return a function for transforming paths into parameters:
+The `match` function returns a function for transforming paths into parameters:
+
+- **path** A string.
+- **options** _(optional)_ The same options as `pathToRegexp`, plus:
+  - **decode** Function for decoding strings for params, or `false` to disable entirely. (default: `decodeURIComponent`)
 
 ```js
 // Make sure you consistently `decode` segments.
@@ -197,142 +196,83 @@ fn("/invalid"); //=> false
 fn("/user/caf%C3%A9"); //=> { path: '/user/caf%C3%A9', index: 0, params: { id: 'café' } }
 ```
 
-The `match` function can be used to custom match named parameters. For example, this can be used to whitelist a small number of valid paths:
-
-```js
-const urlMatch = match("/users/:id/:tab(home|photos|bio)", {
-  decode: decodeURIComponent,
-});
-
-urlMatch("/users/1234/photos");
-//=> { path: '/users/1234/photos', index: 0, params: { id: '1234', tab: 'photos' } }
-
-urlMatch("/users/1234/bio");
-//=> { path: '/users/1234/bio', index: 0, params: { id: '1234', tab: 'bio' } }
-
-urlMatch("/users/1234/otherstuff");
-//=> false
-```
-
-#### Process Pathname
-
-You should make sure variations of the same path match the expected `path`. Here's one possible solution using `encode`:
-
-```js
-const fn = match("/café", { encode: encodeURI });
-
-fn("/caf%C3%A9"); //=> { path: '/caf%C3%A9', index: 0, params: {} }
-```
-
-**Note:** [`URL`](https://developer.mozilla.org/en-US/docs/Web/API/URL) encodes paths, so `/café` would be normalized to `/caf%C3%A9` and match in the above example.
-
-##### Alternative Using Normalize
-
-Sometimes you won't have already normalized paths to use, so you could normalize it yourself before matching:
-
-```js
-/**
- * Normalize a pathname for matching, replaces multiple slashes with a single
- * slash and normalizes unicode characters to "NFC". When using this method,
- * `decode` should be an identity function so you don't decode strings twice.
- */
-function normalizePathname(pathname: string) {
-  return (
-    decodeURI(pathname)
-      // Replaces repeated slashes in the URL.
-      .replace(/\/+/g, "/")
-      // Reference: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/normalize
-      // Note: Missing native IE support, may want to skip this step.
-      .normalize()
-  );
-}
-
-// Two possible ways of writing `/café`:
-const re = pathToRegexp("/caf\u00E9");
-const input = encodeURI("/cafe\u0301");
-
-re.test(input); //=> false
-re.test(normalizePathname(input)); //=> true
-```
-
-### Parse
-
-The `parse` function will return a list of strings and keys from a path string:
-
-```js
-const tokens = parse("/route/:foo/(.*)");
-
-console.log(tokens[0]);
-//=> "/route"
-
-console.log(tokens[1]);
-//=> { name: 'foo', prefix: '/', suffix: '', pattern: '[^\\/#\\?]+?', modifier: '' }
-
-console.log(tokens[2]);
-//=> { name: 0, prefix: '/', suffix: '', pattern: '.*', modifier: '' }
-```
-
-**Note:** This method only works with strings.
+**Note:** Setting `decode: false` disables the "splitting" behavior of repeated parameters, which is useful if you need the exactly matched parameter back.
 
 ### Compile ("Reverse" Path-To-RegExp)
 
 The `compile` function will return a function for transforming parameters into a valid path:
 
+- **path** A string.
+- **options** _(optional)_ Similar to `pathToRegexp` (`delimiter`, `encodePath`, `sensitive`, and `loose`), plus:
+  - **validate** When `false` the function can produce an invalid (unmatched) path. (default: `true`)
+  - **encode** Function for encoding input strings for output into the path, or `false` to disable entirely. (default: `encodeURIComponent`)
+
 ```js
-// Make sure you encode your path segments consistently.
-const toPath = compile("/user/:id", { encode: encodeURIComponent });
+const toPath = compile("/user/:id");
 
 toPath({ id: 123 }); //=> "/user/123"
 toPath({ id: "café" }); //=> "/user/caf%C3%A9"
 toPath({ id: ":/" }); //=> "/user/%3A%2F"
 
-// Without `encode`, you need to make sure inputs are encoded correctly.
-// (Note: You can use `validate: false` to create an invalid paths.)
-const toPathRaw = compile("/user/:id", { validate: false });
+// When disabling `encode`, you need to make sure inputs are encoded correctly. No arrays are accepted.
+const toPathRaw = compile("/user/:id", { encode: false });
 
 toPathRaw({ id: "%3A%2F" }); //=> "/user/%3A%2F"
-toPathRaw({ id: ":/" }); //=> "/user/:/"
+toPathRaw({ id: ":/" }); //=> "/user/:/", throws when `validate: false` is not set.
 
-const toPathRepeated = compile("/:segment+");
+const toPathRepeated = compile("{/:segment}+");
 
-toPathRepeated({ segment: "foo" }); //=> "/foo"
+toPathRepeated({ segment: ["foo"] }); //=> "/foo"
 toPathRepeated({ segment: ["a", "b", "c"] }); //=> "/a/b/c"
 
 const toPathRegexp = compile("/user/:id(\\d+)");
 
-toPathRegexp({ id: 123 }); //=> "/user/123"
 toPathRegexp({ id: "123" }); //=> "/user/123"
 ```
 
-**Note:** The generated function will throw on invalid input.
+## Developers
 
-### Working with Tokens
+- If you are rewriting paths with match and compiler, consider using `encode: false` and `decode: false` to keep raw paths passed around.
+- To ensure matches work on paths containing characters usually encoded, consider using [encodeurl](https://github.com/pillarjs/encodeurl) for `encodePath`.
+- If matches are intended to be exact, you need to set `loose: ''`, `trailing: false`, and `sensitive: true`.
 
-Path-To-RegExp exposes the two functions used internally that accept an array of tokens:
+### Parse
 
-- `tokensToRegexp(tokens, keys?, options?)` Transform an array of tokens into a matching regular expression.
-- `tokensToFunction(tokens)` Transform an array of tokens into a path generator function.
+A `parse` function is available and returns `TokenData`, the set of tokens and other metadata parsed from the input string. `TokenData` is can passed directly into `pathToRegexp`, `match`, and `compile`. It accepts only two options, `delimiter` and `encodePath`, which makes those options redundant in the above methods.
 
-#### Token Information
+### Token Information
 
 - `name` The name of the token (`string` for named or `number` for unnamed index)
 - `prefix` The prefix string for the segment (e.g. `"/"`)
 - `suffix` The suffix string for the segment (e.g. `""`)
 - `pattern` The RegExp used to match this token (`string`)
 - `modifier` The modifier character used for the segment (e.g. `?`)
+- `separator` _(optional)_ The string used to separate repeated parameters (modifier is `+` or `*`)
+- `optional` _(optional)_ A boolean used to indicate whether the parameter is optional (modifier is `?` or `*`)
 
-## Compatibility with Express <= 4.x
+## Errors
 
-Path-To-RegExp breaks compatibility with Express <= `4.x`:
+An effort has been made to ensure ambiguous paths from previous releases throw an error. This means you might be seeing an error when things worked before.
 
-- RegExp special characters can only be used in a parameter
-  - Express.js 4.x supported `RegExp` special characters regardless of position - this is considered a bug
-- Parameters have suffixes that augment meaning - `*`, `+` and `?`. E.g. `/:user*`
-- No wildcard asterisk (`*`) - use parameters instead (`(.*)` or `:splat*`)
+### Unexpected `?`, `*`, or `+`
 
-## Live Demo
+In previous major versions, `/` or `.` were used as implicit prefixes of parameters. So `/:key?` was implicitly `{/:key}?`.
 
-You can see a live demo of this library in use at [express-route-tester](http://forbeslindesay.github.io/express-route-tester/).
+This has been made explicit. Assuming `?` as the modifier, if you have a `/` or `.` before the parameter, you want `{.:ext}?` or `{/:ext}?`. If not, you want `{:ext}?`.
+
+### Unexpected `!`, `@`, or `;`
+
+These characters have been reserved for future use.
+
+### Express <= 4.x
+
+Path-To-RegExp breaks compatibility with Express <= `4.x` in the following ways:
+
+- The only part of the string that is a regex is within `()`.
+  - In Express.js 4.x, everything was passed as-is after a simple replacement, so you could write `/[a-z]+` to match `/test`.
+- The `?` optional character must be used after `{}`.
+- Some characters have new meaning or have been reserved (`{}?*+@!;`).
+- The parameter name now supports all unicode identifier characters, previously it was only `[a-z0-9]`.
 
 ## License
 

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -1614,6 +1614,9 @@ const MATCH_TESTS: MatchTestSet[] = [
   },
   {
     path: "{:test}*",
+    testOptions: {
+      skip: true,
+    },
     tests: [
       {
         input: "test",
@@ -1638,6 +1641,9 @@ const MATCH_TESTS: MatchTestSet[] = [
   },
   {
     path: "{:test}+",
+    testOptions: {
+      skip: true,
+    },
     tests: [
       {
         input: "test",

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -2540,6 +2540,11 @@ const MATCH_TESTS: MatchTestSet[] = [
     path: "name{/:attr1}?{-:attr2}?{-:attr3}?",
     tests: [
       {
+        input: "name",
+        matches: ["name", undefined, undefined, undefined],
+        expected: { path: "name", index: 0, params: {} },
+      },
+      {
         input: "name/test",
         matches: ["name/test", "test", undefined, undefined],
         expected: {
@@ -2573,6 +2578,53 @@ const MATCH_TESTS: MatchTestSet[] = [
           path: "name/1-2-3",
           index: 0,
           params: { attr1: "1", attr2: "2", attr3: "3" },
+        },
+      },
+      {
+        input: "name/foo-bar/route",
+        matches: null,
+        expected: false,
+      },
+      {
+        input: "name/test/route",
+        matches: null,
+        expected: false,
+      },
+    ],
+  },
+  {
+    path: "name{/:attrs;-}*",
+    tests: [
+      {
+        input: "name",
+        matches: ["name", undefined],
+        expected: { path: "name", index: 0, params: {} },
+      },
+      {
+        input: "name/1",
+        matches: ["name/1", "1"],
+        expected: {
+          path: "name/1",
+          index: 0,
+          params: { attrs: ["1"] },
+        },
+      },
+      {
+        input: "name/1-2",
+        matches: ["name/1-2", "1-2"],
+        expected: {
+          path: "name/1-2",
+          index: 0,
+          params: { attrs: ["1", "2"] },
+        },
+      },
+      {
+        input: "name/1-2-3",
+        matches: ["name/1-2-3", "1-2-3"],
+        expected: {
+          path: "name/1-2-3",
+          index: 0,
+          params: { attrs: ["1", "2", "3"] },
         },
       },
       {

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -37,25 +37,29 @@ const PARSER_TESTS: ParserTestSet[] = [
   {
     path: "/:test",
     expected: [
-      { name: "test", prefix: "/", suffix: "", pattern: "", modifier: "" },
+      "/",
+      { name: "test", prefix: "", suffix: "", pattern: "", modifier: "" },
     ],
   },
   {
     path: "/:0",
     expected: [
-      { name: "0", prefix: "/", suffix: "", pattern: "", modifier: "" },
+      "/",
+      { name: "0", prefix: "", suffix: "", pattern: "", modifier: "" },
     ],
   },
   {
     path: "/:_",
     expected: [
-      { name: "_", prefix: "/", suffix: "", pattern: "", modifier: "" },
+      "/",
+      { name: "_", prefix: "", suffix: "", pattern: "", modifier: "" },
     ],
   },
   {
     path: "/:café",
     expected: [
-      { name: "café", prefix: "/", suffix: "", pattern: "", modifier: "" },
+      "/",
+      { name: "café", prefix: "", suffix: "", pattern: "", modifier: "" },
     ],
   },
 ];
@@ -143,7 +147,7 @@ const COMPILE_TESTS: CompileTestSet[] = [
     ],
   },
   {
-    path: "/:test?",
+    path: "{/:test}?",
     options: { encode: false },
     tests: [
       { input: undefined, expected: "" },
@@ -165,7 +169,7 @@ const COMPILE_TESTS: CompileTestSet[] = [
     ],
   },
   {
-    path: "/:test*",
+    path: "{/:test}*",
     tests: [
       { input: undefined, expected: "" },
       { input: {}, expected: "" },
@@ -177,7 +181,7 @@ const COMPILE_TESTS: CompileTestSet[] = [
     ],
   },
   {
-    path: "/:test*",
+    path: "{/:test}*",
     options: { encode: false },
     tests: [
       { input: undefined, expected: "" },
@@ -1115,7 +1119,7 @@ const MATCH_TESTS: MatchTestSet[] = [
    * Optional.
    */
   {
-    path: "/:test?",
+    path: "{/:test}?",
     tests: [
       {
         input: "/route",
@@ -1145,7 +1149,7 @@ const MATCH_TESTS: MatchTestSet[] = [
     ],
   },
   {
-    path: "/:test?",
+    path: "{/:test}?",
     options: {
       trailing: false,
     },
@@ -1165,7 +1169,7 @@ const MATCH_TESTS: MatchTestSet[] = [
     ],
   },
   {
-    path: "/:test?/bar",
+    path: "{/:test}?/bar",
     tests: [
       {
         input: "/bar",
@@ -1190,7 +1194,7 @@ const MATCH_TESTS: MatchTestSet[] = [
     ],
   },
   {
-    path: "/:test?-bar",
+    path: "{/:test}?-bar",
     tests: [
       {
         input: "-bar",
@@ -1209,12 +1213,32 @@ const MATCH_TESTS: MatchTestSet[] = [
       },
     ],
   },
+  {
+    path: "/{:test}?-bar",
+    tests: [
+      {
+        input: "/-bar",
+        matches: ["/-bar", undefined],
+        expected: { path: "/-bar", index: 0, params: {} },
+      },
+      {
+        input: "/foo-bar",
+        matches: ["/foo-bar", "foo"],
+        expected: { path: "/foo-bar", index: 0, params: { test: "foo" } },
+      },
+      {
+        input: "/foo-bar/",
+        matches: ["/foo-bar/", "foo"],
+        expected: { path: "/foo-bar/", index: 0, params: { test: "foo" } },
+      },
+    ],
+  },
 
   /**
    * Zero or more times.
    */
   {
-    path: "/:test*",
+    path: "{/:test}*",
     tests: [
       {
         input: "/",
@@ -1252,7 +1276,7 @@ const MATCH_TESTS: MatchTestSet[] = [
     ],
   },
   {
-    path: "/:test*-bar",
+    path: "{/:test}*-bar",
     tests: [
       {
         input: "-bar",
@@ -1285,7 +1309,7 @@ const MATCH_TESTS: MatchTestSet[] = [
    * One or more times.
    */
   {
-    path: "/:test+",
+    path: "{/:test}+",
     tests: [
       {
         input: "/",
@@ -1323,7 +1347,7 @@ const MATCH_TESTS: MatchTestSet[] = [
     ],
   },
   {
-    path: "/:test+-bar",
+    path: "{/:test}+-bar",
     tests: [
       {
         input: "-bar",
@@ -1479,7 +1503,7 @@ const MATCH_TESTS: MatchTestSet[] = [
     ],
   },
   {
-    path: "/:test(abc|xyz)*",
+    path: "{/:test(abc|xyz)}*",
     tests: [
       {
         input: "/",
@@ -1574,7 +1598,7 @@ const MATCH_TESTS: MatchTestSet[] = [
     ],
   },
   {
-    path: ":test?",
+    path: "{:test}?",
     tests: [
       {
         input: "test",
@@ -1589,7 +1613,7 @@ const MATCH_TESTS: MatchTestSet[] = [
     ],
   },
   {
-    path: ":test*",
+    path: "{:test}*",
     tests: [
       {
         input: "test",
@@ -1613,7 +1637,7 @@ const MATCH_TESTS: MatchTestSet[] = [
     ],
   },
   {
-    path: ":test+",
+    path: "{:test}+",
     tests: [
       {
         input: "test",
@@ -1752,7 +1776,7 @@ const MATCH_TESTS: MatchTestSet[] = [
     ],
   },
   {
-    path: "/test.:format(\\w+)?",
+    path: "/test{.:format(\\w+)}?",
     tests: [
       {
         input: "/test",
@@ -1767,7 +1791,7 @@ const MATCH_TESTS: MatchTestSet[] = [
     ],
   },
   {
-    path: "/test.:format(\\w+)+",
+    path: "/test{.:format(\\w+)}+",
     tests: [
       {
         input: "/test",
@@ -1855,7 +1879,7 @@ const MATCH_TESTS: MatchTestSet[] = [
     ],
   },
   {
-    path: "/:test.:format?",
+    path: "/:test{.:format}?",
     tests: [
       {
         input: "/route",
@@ -1926,7 +1950,7 @@ const MATCH_TESTS: MatchTestSet[] = [
     ],
   },
   {
-    path: "/(\\d+)?",
+    path: "{/(\\d+)}?",
     tests: [
       {
         input: "/",
@@ -2029,7 +2053,7 @@ const MATCH_TESTS: MatchTestSet[] = [
     ],
   },
   {
-    path: "/test\\/:uid(u\\d+)?:cid(c\\d+)?",
+    path: "/test/{:uid(u\\d+)}?{:cid(c\\d+)}?",
     tests: [
       {
         input: "/test/u123",
@@ -2147,7 +2171,7 @@ const MATCH_TESTS: MatchTestSet[] = [
     ],
   },
   {
-    path: "/:foo+bar",
+    path: "{/:foo}+bar",
     tests: [
       {
         input: "/foobar",
@@ -2171,7 +2195,7 @@ const MATCH_TESTS: MatchTestSet[] = [
     ],
   },
   {
-    path: "\\/:pre?baz",
+    path: "/{:pre}?baz",
     tests: [
       {
         input: "/foobaz",
@@ -2186,7 +2210,7 @@ const MATCH_TESTS: MatchTestSet[] = [
     ],
   },
   {
-    path: "/:foo\\(:bar?\\)",
+    path: "/:foo\\({:bar}?\\)",
     tests: [
       {
         input: "/hello(world)",
@@ -2209,7 +2233,7 @@ const MATCH_TESTS: MatchTestSet[] = [
     ],
   },
   {
-    path: "/:postType(video|audio|text)(\\+.+)?",
+    path: "/:postType(video|audio|text){(\\+.+)}?",
     tests: [
       {
         input: "/video",
@@ -2233,7 +2257,7 @@ const MATCH_TESTS: MatchTestSet[] = [
     ],
   },
   {
-    path: "/:foo?/:bar?-ext",
+    path: "{/:foo}?{/:bar}?-ext",
     tests: [
       {
         input: "/-ext",
@@ -2271,7 +2295,7 @@ const MATCH_TESTS: MatchTestSet[] = [
     ],
   },
   {
-    path: "/:required/:optional?-ext",
+    path: "/:required{/:optional}?-ext",
     tests: [
       {
         input: "/foo-ext",
@@ -2405,7 +2429,7 @@ const MATCH_TESTS: MatchTestSet[] = [
     ],
   },
   {
-    path: "mail.:domain?.com",
+    path: "mail{.:domain}?.com",
     options: {
       delimiter: ".",
     },
@@ -2507,7 +2531,7 @@ const MATCH_TESTS: MatchTestSet[] = [
     ],
   },
   {
-    path: "name/:attr1?{-:attr2}?{-:attr3}?",
+    path: "name{/:attr1}?{-:attr2}?{-:attr3}?",
     tests: [
       {
         input: "name/test",
@@ -2611,7 +2635,7 @@ const MATCH_TESTS: MatchTestSet[] = [
    * https://github.com/pillarjs/path-to-regexp/issues/206
    */
   {
-    path: "/user(s)?/:user",
+    path: "/user{(s)}?/:user",
     tests: [
       {
         input: "/user/123",
@@ -2646,57 +2670,10 @@ const MATCH_TESTS: MatchTestSet[] = [
   },
 
   /**
-   * https://github.com/pillarjs/path-to-regexp/issues/260
-   */
-  {
-    path: ":name*",
-    tests: [
-      {
-        input: "foobar",
-        matches: ["foobar", "foobar"],
-        expected: { path: "foobar", index: 0, params: { name: ["foobar"] } },
-      },
-      {
-        input: "foo/bar",
-        matches: ["foo/bar", "foo/bar"],
-        expected: {
-          path: "foo/bar",
-          index: 0,
-          params: { name: ["foo", "bar"] },
-        },
-      },
-    ],
-  },
-  {
-    path: ":name+",
-    tests: [
-      {
-        input: "",
-        matches: null,
-        expected: false,
-      },
-      {
-        input: "foobar",
-        matches: ["foobar", "foobar"],
-        expected: { path: "foobar", index: 0, params: { name: ["foobar"] } },
-      },
-      {
-        input: "foo/bar",
-        matches: ["foo/bar", "foo/bar"],
-        expected: {
-          path: "foo/bar",
-          index: 0,
-          params: { name: ["foo", "bar"] },
-        },
-      },
-    ],
-  },
-
-  /**
    * https://github.com/pillarjs/path-to-regexp/pull/270
    */
   {
-    path: "/files/:path*.:ext*",
+    path: "/files{/:path}*{.:ext}*",
     tests: [
       {
         input: "/files/hello/world.txt",
@@ -2729,7 +2706,7 @@ const MATCH_TESTS: MatchTestSet[] = [
     ],
   },
   {
-    path: "/foo/:bar*",
+    path: "/foo{/:bar}*",
     tests: [
       {
         input: "/foo/test1//test2",
@@ -2851,7 +2828,7 @@ const MATCH_TESTS: MatchTestSet[] = [
    */
   {
     path: "/test",
-    options: { loose: "" },
+    options: { loose: false },
     tests: [
       {
         input: "/test",
@@ -2878,7 +2855,7 @@ describe("path-to-regexp", () => {
       const expectedKeys = [
         {
           name: "id",
-          prefix: "/",
+          prefix: "",
           suffix: "",
           modifier: "",
           pattern: "",
@@ -2928,7 +2905,11 @@ describe("path-to-regexp", () => {
     it("should throw on nested groups", () => {
       expect(() => {
         pathToRegexp.pathToRegexp("/{a{b:foo}}");
-      }).toThrow(new TypeError("Unexpected { at 3, expected }"));
+      }).toThrow(
+        new TypeError(
+          "Unexpected { at 3, expected }: https://git.new/pathToRegexpError",
+        ),
+      );
     });
   });
 
@@ -2992,11 +2973,11 @@ describe("path-to-regexp", () => {
 
       expect(() => {
         toPath({ foo: "abc" });
-      }).toThrow(new TypeError('Invalid value for "foo": "/abc"'));
+      }).toThrow(new TypeError('Invalid value for "foo": "abc"'));
     });
 
     it("should throw when expecting a repeated value", () => {
-      const toPath = pathToRegexp.compile("/:foo+");
+      const toPath = pathToRegexp.compile("{/:foo}+");
 
       expect(() => {
         toPath({ foo: [] });
@@ -3012,7 +2993,7 @@ describe("path-to-regexp", () => {
     });
 
     it("should throw when a repeated param is not an array", () => {
-      const toPath = pathToRegexp.compile("/:foo+");
+      const toPath = pathToRegexp.compile("{/:foo}+");
 
       expect(() => {
         toPath({ foo: "a" });
@@ -3020,7 +3001,7 @@ describe("path-to-regexp", () => {
     });
 
     it("should throw when an array value is not a string", () => {
-      const toPath = pathToRegexp.compile("/:foo+");
+      const toPath = pathToRegexp.compile("{/:foo}+");
 
       expect(() => {
         toPath({ foo: [1, "a"] });
@@ -3028,7 +3009,7 @@ describe("path-to-regexp", () => {
     });
 
     it("should throw when repeated value does not match", () => {
-      const toPath = pathToRegexp.compile("/:foo(\\d+)+");
+      const toPath = pathToRegexp.compile("{/:foo(\\d+)}+");
 
       expect(() => {
         toPath({ foo: ["1", "2", "3", "a"] });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 const DEFAULT_DELIMITER = "/";
+const DEFAULT_PREFIXES = "./";
 const NOOP_VALUE = (value: string) => value;
 const ID_CHAR = /^\p{XID_Continue}$/u;
 
@@ -18,10 +19,6 @@ export interface ParseOptions {
    */
   delimiter?: string;
   /**
-   * List of characters to automatically consider prefixes when parsing.
-   */
-  prefixes?: string;
-  /**
    * Function for encoding input strings for output into path.
    */
   encodePath?: Encode;
@@ -33,9 +30,9 @@ export interface PathToRegexpOptions extends ParseOptions {
    */
   sensitive?: boolean;
   /**
-   * Set characters to treat as "loose" and allow arbitrarily repeated. (default: `/`)
+   * Allow delimiter to be arbitrarily repeated. (default: `true`)
    */
-  loose?: string;
+  loose?: boolean;
   /**
    * When `true` the regexp will match to the end of the string. (default: `true`)
    */
@@ -52,7 +49,7 @@ export interface PathToRegexpOptions extends ParseOptions {
 
 export interface MatchOptions extends PathToRegexpOptions {
   /**
-   * Function for decoding strings for params.
+   * Function for decoding strings for params, or `false` to disable entirely. (default: `decodeURIComponent`)
    */
   decode?: Decode | false;
 }
@@ -63,15 +60,15 @@ export interface CompileOptions extends ParseOptions {
    */
   sensitive?: boolean;
   /**
-   * Set characters to treat as "loose" and allow arbitrarily repeated. (default: `/`)
+   * Allow delimiter to be arbitrarily repeated. (default: `true`)
    */
-  loose?: string;
+  loose?: boolean;
   /**
    * When `false` the function can produce an invalid (unmatched) path. (default: `true`)
    */
   validate?: boolean;
   /**
-   * Function for encoding input strings for output into the path. (default: `encodeURIComponent`)
+   * Function for encoding input strings for output into the path, or `false` to disable entirely. (default: `encodeURIComponent`)
    */
   encode?: Encode | false;
 }
@@ -215,7 +212,9 @@ class Iter {
     const value = this.tryConsume(type);
     if (value !== undefined) return value;
     const { type: nextType, index } = this.peek();
-    throw new TypeError(`Unexpected ${nextType} at ${index}, expected ${type}`);
+    throw new TypeError(
+      `Unexpected ${nextType} at ${index}, expected ${type}: https://git.new/pathToRegexpError`,
+    );
   }
 
   text(): string {
@@ -227,8 +226,10 @@ class Iter {
     return result;
   }
 
-  modifier(): string | undefined {
-    return this.tryConsume("?") || this.tryConsume("*") || this.tryConsume("+");
+  modifier(): string {
+    return (
+      this.tryConsume("?") || this.tryConsume("*") || this.tryConsume("+") || ""
+    );
   }
 }
 
@@ -246,73 +247,48 @@ export class TokenData {
  * Parse a string for the raw tokens.
  */
 export function parse(str: string, options: ParseOptions = {}): TokenData {
-  const {
-    prefixes = "./",
-    delimiter = DEFAULT_DELIMITER,
-    encodePath = NOOP_VALUE,
-  } = options;
+  const { delimiter = DEFAULT_DELIMITER, encodePath = NOOP_VALUE } = options;
   const tokens: Token[] = [];
   const it = lexer(str);
   let key = 0;
-  let path = "";
 
   do {
-    const char = it.tryConsume("CHAR");
+    const path = it.text();
+    if (path) tokens.push(encodePath(path));
+
     const name = it.tryConsume("NAME");
-    const pattern = it.tryConsume("PATTERN");
+    const pattern = it.tryConsume("PATTERN") || "";
 
     if (name || pattern) {
-      let prefix = char || "";
-      const modifier = it.modifier();
+      tokens.push({
+        name: name || String(key++),
+        prefix: "",
+        suffix: "",
+        pattern,
+        modifier: "",
+      });
 
-      if (!prefixes.includes(prefix)) {
-        path += prefix;
-        prefix = "";
+      const next = it.peek();
+      if (next.type === "*") {
+        throw new TypeError(
+          `Unexpected * at ${next.index}, you probably want \`/*\` or \`{/:foo}*\`: https://git.new/pathToRegexpError`,
+        );
       }
 
-      if (path) {
-        tokens.push(encodePath(path));
-        path = "";
-      }
-
-      tokens.push(
-        toKey(
-          encodePath,
-          delimiter,
-          name || String(key++),
-          pattern,
-          prefix,
-          "",
-          modifier,
-        ),
-      );
       continue;
-    }
-
-    const value = char || it.tryConsume("ESCAPED");
-    if (value) {
-      path += value;
-      continue;
-    }
-
-    if (path) {
-      tokens.push(encodePath(path));
-      path = "";
     }
 
     const asterisk = it.tryConsume("*");
     if (asterisk) {
-      tokens.push(
-        toKey(
-          encodePath,
-          delimiter,
-          String(key++),
-          `[^${escape(delimiter)}]*`,
-          "",
-          "",
-          asterisk,
-        ),
-      );
+      tokens.push({
+        name: String(key++),
+        prefix: "",
+        suffix: "",
+        pattern: `[^${escape(delimiter)}]*`,
+        modifier: "*",
+        separator: delimiter,
+        optional: true,
+      });
       continue;
     }
 
@@ -320,22 +296,27 @@ export function parse(str: string, options: ParseOptions = {}): TokenData {
     if (open) {
       const prefix = it.text();
       const name = it.tryConsume("NAME");
-      const pattern = it.tryConsume("PATTERN");
+      const pattern = it.tryConsume("PATTERN") || "";
       const suffix = it.text();
 
       it.consume("}");
 
-      tokens.push(
-        toKey(
-          encodePath,
-          delimiter,
-          name || (pattern ? String(key++) : ""),
-          pattern,
-          prefix,
-          suffix,
-          it.modifier(),
-        ),
-      );
+      const modifier = it.modifier();
+      const optional = modifier === "?" || modifier === "*";
+      const separator =
+        modifier === "*" || modifier === "+"
+          ? prefix + suffix || delimiter
+          : undefined;
+
+      tokens.push({
+        name: name || (pattern ? String(key++) : ""),
+        prefix: encodePath(prefix),
+        suffix: encodePath(suffix),
+        pattern,
+        modifier,
+        separator,
+        optional,
+      });
       continue;
     }
 
@@ -346,32 +327,14 @@ export function parse(str: string, options: ParseOptions = {}): TokenData {
   return new TokenData(tokens, delimiter);
 }
 
-function toKey(
-  encode: Encode,
-  delimiter: string,
-  name: string,
-  pattern = "",
-  inputPrefix = "",
-  inputSuffix = "",
-  modifier = "",
-): Key {
-  const prefix = encode(inputPrefix);
-  const suffix = encode(inputSuffix);
-  const separator =
-    modifier === "*" || modifier === "+"
-      ? prefix + suffix || delimiter
-      : undefined;
-  return { name, prefix, suffix, pattern, modifier, separator };
-}
-
 /**
  * Compile a string to a template function for the path.
  */
 export function compile<P extends object = object>(
-  value: Path,
+  path: Path,
   options: CompileOptions = {},
 ) {
-  const data = value instanceof TokenData ? value : parse(value, options);
+  const data = path instanceof TokenData ? path : parse(path, options);
   return compileTokens<P>(data, options);
 }
 
@@ -389,7 +352,6 @@ function tokenToFunction(
     return () => token;
   }
 
-  const optional = token.modifier === "?" || token.modifier === "*";
   const encodeValue = encode || NOOP_VALUE;
 
   if (encode && token.separator) {
@@ -412,7 +374,7 @@ function tokenToFunction(
       );
     };
 
-    if (optional) {
+    if (token.optional) {
       return (data): string => {
         const value = data[token.name];
         if (value == null) return "";
@@ -433,7 +395,7 @@ function tokenToFunction(
     return token.prefix + encodeValue(value) + token.suffix;
   };
 
-  if (optional) {
+  if (token.optional) {
     return (data): string => {
       const value = data[token.name];
       if (value == null) return "";
@@ -456,11 +418,11 @@ function compileTokens<P extends ParamData>(
 ): PathFunction<P> {
   const {
     encode = encodeURIComponent,
-    loose = DEFAULT_DELIMITER,
+    loose = true,
     validate = true,
   } = options;
   const reFlags = flags(options);
-  const stringify = toStringify(loose);
+  const stringify = toStringify(loose, data.delimiter);
   const keyToRegexp = toKeyRegexp(stringify, data.delimiter);
 
   // Compile all the tokens into regexps.
@@ -514,24 +476,16 @@ export type MatchFunction<P extends ParamData> = (path: string) => Match<P>;
  * Create path match function from `path-to-regexp` spec.
  */
 export function match<P extends ParamData>(
-  str: Path,
+  path: Path,
   options: MatchOptions = {},
 ): MatchFunction<P> {
-  const re = pathToRegexp(str, options);
-  return matchRegexp<P>(re, options);
-}
+  const { decode = decodeURIComponent, loose = true } = options;
+  const data = path instanceof TokenData ? path : parse(path, options);
+  const stringify = toStringify(loose, data.delimiter);
+  const keys: Key[] = [];
+  const re = tokensToRegexp(data, keys, options);
 
-/**
- * Create a path match function from `path-to-regexp` output.
- */
-function matchRegexp<P extends ParamData>(
-  re: PathRegExp,
-  options: MatchOptions,
-): MatchFunction<P> {
-  const { decode = decodeURIComponent, loose = DEFAULT_DELIMITER } = options;
-  const stringify = toStringify(loose);
-
-  const decoders = re.keys.map((key) => {
+  const decoders = keys.map((key) => {
     if (decode && key.separator) {
       const re = new RegExp(stringify(key.separator), "g");
       return (value: string) => value.split(re).map(decode);
@@ -550,7 +504,7 @@ function matchRegexp<P extends ParamData>(
     for (let i = 1; i < m.length; i++) {
       if (m[i] === undefined) continue;
 
-      const key = re.keys[i - 1];
+      const key = keys[i - 1];
       const decoder = decoders[i - 1];
       params[key.name] = decoder(m[i]);
     }
@@ -576,10 +530,10 @@ function looseReplacer(value: string, loose: string) {
 /**
  * Encode all non-delimiter characters using the encode function.
  */
-function toStringify(loose: string) {
+function toStringify(loose: boolean, delimiter: string) {
   if (!loose) return escape;
 
-  const re = new RegExp(`[^${escape(loose)}]+|(.)`, "g");
+  const re = new RegExp(`[^${escape(delimiter)}]+|(.)`, "g");
   return (value: string) => value.replace(re, looseReplacer);
 }
 
@@ -600,6 +554,7 @@ export interface Key {
   pattern: string;
   modifier: string;
   separator?: string;
+  optional?: boolean;
 }
 
 /**
@@ -615,13 +570,8 @@ function tokensToRegexp(
   keys: Key[],
   options: PathToRegexpOptions,
 ): RegExp {
-  const {
-    trailing = true,
-    start = true,
-    end = true,
-    loose = DEFAULT_DELIMITER,
-  } = options;
-  const stringify = toStringify(loose);
+  const { trailing = true, start = true, end = true, loose = true } = options;
+  const stringify = toStringify(loose, data.delimiter);
   const keyToRegexp = toKeyRegexp(stringify, data.delimiter);
   let pattern = start ? "^" : "";
 
@@ -652,12 +602,12 @@ function toKeyRegexp(stringify: Encode, delimiter: string) {
 
     if (key.name) {
       const pattern = key.pattern || segmentPattern;
+      const mod = key.optional ? "?" : "";
       if (key.separator) {
-        const mod = key.modifier === "*" ? "?" : "";
         const split = stringify(key.separator);
         return `(?:${prefix}((?:${pattern})(?:${split}(?:${pattern}))*)${suffix})${mod}`;
       } else {
-        return `(?:${prefix}(${pattern})${suffix})${key.modifier}`;
+        return `(?:${prefix}(${pattern})${suffix})${mod}`;
       }
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -87,6 +87,7 @@ type TokenType =
   // Reserved for use.
   | "!"
   | "@"
+  | ","
   | ";";
 
 /**
@@ -102,6 +103,7 @@ const SIMPLE_TOKENS: Record<string, TokenType> = {
   "!": "!",
   "@": "@",
   ";": ";",
+  ",": ",",
   "*": "*",
   "+": "+",
   "?": "?",


### PR DESCRIPTION
Demo using explicit `{}` for prefix/suffix instead of implicit `/` and `.`, and nothing in other positions. This would allow for much clearer error and edge case handling of things like `-:path*` which is meaningless today, while `/:path*` is actually useful. It more closely aligns behavior with some other path matching libraries, such as Rails which uses `()` to denotes optional. 

However, it does break compatibility as a result of fixing these quirks. As part of this PR there is a good attempt at ensuring the upgrade path is pretty easy, and it gives clear errors with a link and the exact part of the string where the error occurred. Mostly it'll be `/:path?` to `{/:path}?`. I've also disallowed `/:path*` which could be confused as `*` is now a wildcard, and writing that path is probably a bug. As a result, this does give a simple library upgrade path that adds back `/:path?`, `/:path+`, `/:path*` if needed by users.

It's also fairly easy to write a path rewrite script that'll update the syntax if people want it, both for Express.js 4.x and the current major release.