### PR TITLE
Better type for compile

### DIFF
--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -3047,7 +3047,7 @@ describe("path-to-regexp", () => {
       const toPath = pathToRegexp.compile("{/:foo}+");
 
       expect(() => {
-        toPath({ foo: [1, "a"] });
+        toPath({ foo: [1, "a"] as any });
       }).toThrow(new TypeError('Expected "foo/0" to be a string'));
     });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -320,7 +320,7 @@ export function parse(str: string, options: ParseOptions = {}): TokenData {
 /**
  * Compile a string to a template function for the path.
  */
-export function compile<P extends object = object>(
+export function compile<P extends ParamData = ParamData>(
   path: Path,
   options: CompileOptions = {},
 ) {


### PR DESCRIPTION
As of path-to-regexp 7, parameters to compile should be strings. compileToken's types reflect this, but compile's did not.