### PR TITLE
Add backtrack protection to 6.x

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@types/node": "^20.4.9",
         "@types/semver": "^7.3.1",
         "@vitest/coverage-v8": "^1.4.0",
+        "recheck": "^4.4.5",
         "semver": "^7.3.5",
         "size-limit": "^11.1.2",
         "typescript": "^5.1.6"
@@ -2681,6 +2682,67 @@
       "engines": {
         "node": ">=8.10.0"
       }
+    },
+    "node_modules/recheck": {
+      "version": "4.4.5",
+      "resolved": "https://registry.npmjs.org/recheck/-/recheck-4.4.5.tgz",
+      "integrity": "sha512-J80Ykhr+xxWtvWrfZfPpOR/iw2ijvb4WY8d9AVoN8oHsPP07JT1rCAalUSACMGxM1cvSocb6jppWFjVS6eTTrA==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      },
+      "optionalDependencies": {
+        "recheck-jar": "4.4.5",
+        "recheck-linux-x64": "4.4.5",
+        "recheck-macos-x64": "4.4.5",
+        "recheck-windows-x64": "4.4.5"
+      }
+    },
+    "node_modules/recheck-jar": {
+      "version": "4.4.5",
+      "resolved": "https://registry.npmjs.org/recheck-jar/-/recheck-jar-4.4.5.tgz",
+      "integrity": "sha512-a2kMzcfr+ntT0bObNLY22EUNV6Z6WeZ+DybRmPOUXVWzGcqhRcrK74tpgrYt3FdzTlSh85pqoryAPmrNkwLc0g==",
+      "dev": true,
+      "optional": true
+    },
+    "node_modules/recheck-linux-x64": {
+      "version": "4.4.5",
+      "resolved": "https://registry.npmjs.org/recheck-linux-x64/-/recheck-linux-x64-4.4.5.tgz",
+      "integrity": "sha512-s8OVPCpiSGw+tLCxH3eei7Zp2AoL22kXqLmEtWXi0AnYNwfuTjZmeLn2aQjW8qhs8ZPSkxS7uRIRTeZqR5Fv/Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/recheck-macos-x64": {
+      "version": "4.4.5",
+      "resolved": "https://registry.npmjs.org/recheck-macos-x64/-/recheck-macos-x64-4.4.5.tgz",
+      "integrity": "sha512-Ouup9JwwoKCDclt3Na8+/W2pVbt8FRpzjkDuyM32qTR2TOid1NI+P1GA6/VQAKEOjvaxgGjxhcP/WqAjN+EULA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/recheck-windows-x64": {
+      "version": "4.4.5",
+      "resolved": "https://registry.npmjs.org/recheck-windows-x64/-/recheck-windows-x64-4.4.5.tgz",
+      "integrity": "sha512-mkpzLHu9G9Ztjx8HssJh9k/Xm1d1d/4OoT7etHqFk+k1NGzISCRXBD22DqYF9w8+J4QEzTAoDf8icFt0IGhOEQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/restore-cursor": {
       "version": "4.0.0",
@@ -5421,6 +5483,46 @@
       "requires": {
         "picomatch": "^2.2.1"
       }
+    },
+    "recheck": {
+      "version": "4.4.5",
+      "resolved": "https://registry.npmjs.org/recheck/-/recheck-4.4.5.tgz",
+      "integrity": "sha512-J80Ykhr+xxWtvWrfZfPpOR/iw2ijvb4WY8d9AVoN8oHsPP07JT1rCAalUSACMGxM1cvSocb6jppWFjVS6eTTrA==",
+      "dev": true,
+      "requires": {
+        "recheck-jar": "4.4.5",
+        "recheck-linux-x64": "4.4.5",
+        "recheck-macos-x64": "4.4.5",
+        "recheck-windows-x64": "4.4.5"
+      }
+    },
+    "recheck-jar": {
+      "version": "4.4.5",
+      "resolved": "https://registry.npmjs.org/recheck-jar/-/recheck-jar-4.4.5.tgz",
+      "integrity": "sha512-a2kMzcfr+ntT0bObNLY22EUNV6Z6WeZ+DybRmPOUXVWzGcqhRcrK74tpgrYt3FdzTlSh85pqoryAPmrNkwLc0g==",
+      "dev": true,
+      "optional": true
+    },
+    "recheck-linux-x64": {
+      "version": "4.4.5",
+      "resolved": "https://registry.npmjs.org/recheck-linux-x64/-/recheck-linux-x64-4.4.5.tgz",
+      "integrity": "sha512-s8OVPCpiSGw+tLCxH3eei7Zp2AoL22kXqLmEtWXi0AnYNwfuTjZmeLn2aQjW8qhs8ZPSkxS7uRIRTeZqR5Fv/Q==",
+      "dev": true,
+      "optional": true
+    },
+    "recheck-macos-x64": {
+      "version": "4.4.5",
+      "resolved": "https://registry.npmjs.org/recheck-macos-x64/-/recheck-macos-x64-4.4.5.tgz",
+      "integrity": "sha512-Ouup9JwwoKCDclt3Na8+/W2pVbt8FRpzjkDuyM32qTR2TOid1NI+P1GA6/VQAKEOjvaxgGjxhcP/WqAjN+EULA==",
+      "dev": true,
+      "optional": true
+    },
+    "recheck-windows-x64": {
+      "version": "4.4.5",
+      "resolved": "https://registry.npmjs.org/recheck-windows-x64/-/recheck-windows-x64-4.4.5.tgz",
+      "integrity": "sha512-mkpzLHu9G9Ztjx8HssJh9k/Xm1d1d/4OoT7etHqFk+k1NGzISCRXBD22DqYF9w8+J4QEzTAoDf8icFt0IGhOEQ==",
+      "dev": true,
+      "optional": true
     },
     "restore-cursor": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   "size-limit": [
     {
       "path": "dist.es2015/index.js",
-      "limit": "2 kB"
+      "limit": "2.1 kB"
     }
   ],
   "ts-scripts": {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "@types/node": "^20.4.9",
     "@types/semver": "^7.3.1",
     "@vitest/coverage-v8": "^1.4.0",
+    "recheck": "^4.4.5",
     "semver": "^7.3.5",
     "size-limit": "^11.1.2",
     "typescript": "^5.1.6"

--- a/redos.ts
+++ b/redos.ts
@@ -1,0 +1,21 @@
+import { checkSync } from "recheck";
+import { pathToRegexp } from "./src/index.js";
+
+let safe = 0;
+let fail = 0;
+
+const tests = ["/:x{/foobar/:y}?-:z"];
+
+for (const path of tests) {
+  const regexp = pathToRegexp(path);
+  const result = checkSync(regexp.source, regexp.flags);
+  if (result.status === "safe") {
+    safe++;
+    console.log("Safe:", path, String(regexp));
+  } else {
+    fail++;
+    console.log("Fail:", path, String(regexp));
+  }
+}
+
+console.log("Safe:", safe, "Fail:", fail);

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -1353,7 +1353,7 @@ const TESTS: Test[] = [
         prefix: ".",
         suffix: "",
         modifier: "+",
-        pattern: "[^\\/#\\?]+?",
+        pattern: "(?:(?!\\.)[^\\/#\\?])+?",
       },
     ],
     [
@@ -1397,7 +1397,7 @@ const TESTS: Test[] = [
         prefix: ".",
         suffix: "",
         modifier: "",
-        pattern: "[^\\/#\\?]+?",
+        pattern: "(?:(?!\\.)[^\\/#\\?])+?",
       },
       ".",
     ],
@@ -1430,13 +1430,13 @@ const TESTS: Test[] = [
         prefix: ".",
         suffix: "",
         modifier: "",
-        pattern: "[^\\/#\\?]+?",
+        pattern: "(?:(?!\\.)[^\\/#\\?])+?",
       },
     ],
     [
       ["/route.html", ["/route.html", "route", "html"]],
       ["/route", null],
-      ["/route.html.json", ["/route.html.json", "route", "html.json"]],
+      ["/route.html.json", ["/route.html.json", "route.html", "json"]],
     ],
     [
       [{}, null],
@@ -1459,13 +1459,13 @@ const TESTS: Test[] = [
         prefix: ".",
         suffix: "",
         modifier: "?",
-        pattern: "[^\\/#\\?]+?",
+        pattern: "(?:(?!\\.)[^\\/#\\?])+?",
       },
     ],
     [
       ["/route", ["/route", "route", undefined]],
       ["/route.json", ["/route.json", "route", "json"]],
-      ["/route.json.html", ["/route.json.html", "route", "json.html"]],
+      ["/route.json.html", ["/route.json.html", "route.json", "html"]],
     ],
     [
       [{ test: "route" }, "/route"],
@@ -1491,13 +1491,13 @@ const TESTS: Test[] = [
         prefix: ".",
         suffix: "",
         modifier: "?",
-        pattern: "[^\\/#\\?]+?",
+        pattern: "(?:(?!\\.)[^\\/#\\?])+?",
       },
     ],
     [
       ["/route", ["/route", "route", undefined]],
       ["/route.json", ["/route.json", "route", "json"]],
-      ["/route.json.html", ["/route.json.html", "route", "json.html"]],
+      ["/route.json.html", ["/route.json.html", "route.json", "html"]],
     ],
     [
       [{ test: "route" }, "/route"],
@@ -2084,7 +2084,7 @@ const TESTS: Test[] = [
         prefix: "",
         suffix: "",
         modifier: "?",
-        pattern: "[^\\/#\\?]+?",
+        pattern: "(?:(?!\\()[^\\/#\\?])+?",
       },
       ")",
     ],
@@ -2290,7 +2290,7 @@ const TESTS: Test[] = [
         prefix: ".",
         suffix: "",
         modifier: "",
-        pattern: "[^\\/#\\?]+?",
+        pattern: "(?:(?!\\.)[^\\/#\\?])+?",
       },
     ],
     [
@@ -2356,14 +2356,14 @@ const TESTS: Test[] = [
     [
       {
         name: "foo",
-        pattern: "[^\\/#\\?]+?",
+        pattern: "(?:(?!\\$)[^\\/#\\?])+?",
         prefix: "$",
         suffix: "",
         modifier: "",
       },
       {
         name: "bar",
-        pattern: "[^\\/#\\?]+?",
+        pattern: "(?:(?!\\$)[^\\/#\\?])+?",
         prefix: "$",
         suffix: "",
         modifier: "?",
@@ -2392,14 +2392,14 @@ const TESTS: Test[] = [
       },
       {
         name: "attr2",
-        pattern: "[^\\/#\\?]+?",
+        pattern: "(?:(?!-)[^\\/#\\?])+?",
         prefix: "-",
         suffix: "",
         modifier: "?",
       },
       {
         name: "attr3",
-        pattern: "[^\\/#\\?]+?",
+        pattern: "(?:(?!-)[^\\/#\\?])+?",
         prefix: "-",
         suffix: "",
         modifier: "?",
@@ -2596,39 +2596,6 @@ const TESTS: Test[] = [
       [{ foo: "123" }, "/whatever/123"],
       [{ foo: "#" }, null],
     ],
-  ],
-  /**
-   * https://github.com/pillarjs/path-to-regexp/issues/260
-   */
-  [
-    ":name*",
-    undefined,
-    [
-      {
-        name: "name",
-        prefix: "",
-        suffix: "",
-        modifier: "*",
-        pattern: "[^\\/#\\?]+?",
-      },
-    ],
-    [["foobar", ["foobar", "foobar"]]],
-    [[{ name: "foobar" }, "foobar"]],
-  ],
-  [
-    ":name+",
-    undefined,
-    [
-      {
-        name: "name",
-        prefix: "",
-        suffix: "",
-        modifier: "+",
-        pattern: "[^\\/#\\?]+?",
-      },
-    ],
-    [["foobar", ["foobar", "foobar"]]],
-    [[{ name: "foobar" }, "foobar"]],
   ],
 ];
 

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -2766,6 +2766,24 @@ describe("path-to-regexp", () => {
         pathToRegexp.pathToRegexp("/foo?");
       }).toThrow(new TypeError("Unexpected MODIFIER at 4, expected END"));
     });
+
+    it("should throw on parameters without text between them", () => {
+      expect(() => {
+        pathToRegexp.pathToRegexp("/:x:y");
+      }).toThrow(
+        new TypeError(
+          `Must have text between two parameters, missing text after "x"`,
+        ),
+      );
+    });
+
+    it("should throw on unrepeatable params", () => {
+      expect(() => {
+        pathToRegexp.pathToRegexp("/foo:x*");
+      }).toThrow(
+        new TypeError(`Can not repeat "x" without a prefix and suffix`),
+      );
+    });
   });
 
   describe("tokens", () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -176,7 +176,7 @@ export function parse(str: string, options: ParseOptions = {}): Token[] {
 
     if (prev && !prevText) {
       throw new TypeError(
-        `No support for parameters without text between them after "${(prev as Key).name}"`,
+        `Must have text between two parameters, missing text after "${(prev as Key).name}"`,
       );
     }
 
@@ -583,7 +583,7 @@ export function tokensToRegexp(
         } else {
           if (token.modifier === "+" || token.modifier === "*") {
             throw new TypeError(
-              `Can not repeat ${token.name} with no prefix or suffix, e.g. "/:param${token.modifier}"`,
+              `Can not repeat "${token.name}" without a prefix and suffix`,
             );
           }
 


### PR DESCRIPTION
Closes https://github.com/pillarjs/path-to-regexp/issues/323. It will likely break some existing routes around the edge cases, but it should eliminate the vulnerability when the pattern isn't specified.