### PR TITLE
Update index.js (ensure path is a string before replacement)

### DIFF
--- a/index.js
+++ b/index.js
@@ -65,7 +65,7 @@ function pathToRegexp(path, keys, options) {
     return new RegExp(path.join('|'), flags);
   }
 
-  path = path.replace(
+  path = String(path).replace(
     /\\.|(\/)?(\.)?:(\w+)(\(.*?\))?(\*)?(\?)?|[.*]|\/\(/g,
     function (match, slash, format, key, capture, star, optional, offset) {
       pos = offset + match.length;


### PR DESCRIPTION
Fixes: https://github.com/expressjs/express/issues/5955

Ensure the `path` variable is explicitly converted to a string before applying regex replacements to prevent potential errors with non-string inputs.

This change enhances robustness and correctness in handling various input types.