### PR TITLE
Return the regexp used for matching

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -466,7 +466,7 @@ export function match<P extends ParamData>(
     return (value: string) => value.split(delimiter).map(decode);
   });
 
-  return function match(input: string) {
+  const match = function match(input: string) {
     const m = regexp.exec(input);
     if (!m) return false;
 
@@ -483,6 +483,8 @@ export function match<P extends ParamData>(
 
     return { path, params };
   };
+  match.regexp = regexp;
+  return match;
 }
 
 export function pathToRegexp(


### PR DESCRIPTION
This is an attempt to return the functionality to build a routers tree for express app.
Developers can replace `layer.regexp` by `layer.matchers[0].regexp` in original code from @dougwilson https://github.com/expressjs/express/discussions/5858#discussioncomment-10436717

https://github.com/expressjs/express/discussions/5961