### PR TITLE
Test CI with both Node.js and Bun

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,27 +5,42 @@ on:
 permissions:
   contents: read
 jobs:
-  test:
-    name: Node.js ${{ matrix.node-version }}
+  test-node:
+    name: Node.js (${{ matrix.node-version }})
     runs-on: ubuntu-latest
     strategy:
       matrix:
         node-version:
           - "16"
-          - "*"
+          - "latest"
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
-      - uses: actions/cache@v2
+      - uses: oven-sh/setup-bun@v2
         with:
-          path: ~/.npm
-          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-
-      - run: npm ci
-      - run: npm test
-      - uses: codecov/codecov-action@v1
+          bun-version: "1.2.0"
+      - run: bun install
+      - run: bun run test # runs tests with Vitest
+      - uses: codecov/codecov-action@v5
         with:
-          name: Node.js ${{ matrix.node-version }}
+          name: Node.js (${{ matrix.node-version }})
+  test-bun:
+    name: Bun (${{ matrix.bun-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        bun-version:
+          - "1.2.0"
+          - "latest"
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: ${{ matrix.bun-version }}
+      - run: bun install
+      - run: bun run test:bun # runs tests with Bun
+      - uses: codecov/codecov-action@v5
+        with:
+          name: Bun (${{ matrix.bun-version }})

--- a/Readme.md
+++ b/Readme.md
@@ -10,8 +10,12 @@
 
 ## Installation
 
-```
-npm install path-to-regexp --save
+Install with your choice of package manager: npm, yarn, or bun.
+
+```sh
+npm install path-to-regexp
+yarn add path-to-regexp
+bun add path-to-regexp
 ```
 
 ## Usage
@@ -25,6 +29,8 @@ const {
   stringify,
 } = require("path-to-regexp");
 ```
+
+This library is compatible and tested with Node.js 16+ and Bun 1.2+.
 
 ### Parameters
 

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,0 +1,3 @@
+[test]
+coverage = true
+coverageReporter = ["text", "lcov"]

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "prepare": "ts-scripts install && npm run build",
     "size": "size-limit",
     "specs": "ts-scripts specs",
-    "test": "ts-scripts test && npm run size"
+    "test": "ts-scripts test && npm run size",
+    "test:bun": "bun test && bun run size"
   },
   "devDependencies": {
     "@borderless/ts-scripts": "^0.15.0",


### PR DESCRIPTION
This adds support to run tests in CI using Bun, and keeps Node.js support. It makes running tests 35% faster.

<table>
<tr>
<td align="center" width="50%"><strong>Bun</strong> - 11s</td>
<td align="center" width="50%"><strong>Node</strong> - 17s</td>
</tr>
<tr>
<td align="center" valign="top" width="50%"><img width="314" alt="Screenshot 2025-02-20 at 3 32 02 PM" src="https://github.com/user-attachments/assets/909ffd1f-d58c-4cac-b723-1adef3354574"></td>
<td align="center" valign="top" width="50%"><img width="314" alt="Screenshot 2025-02-20 at 3 32 49 PM" src="https://github.com/user-attachments/assets/eeeb9534-e416-49a8-8e14-0e9aea52d603"></td>
</tr>
</table>

Since Bun supports Jest & Vitest, you'll notice there are no code changes! It just works. (and I did test the Github Action on a fork to verify that it indeed does work)

This also changes `npm install` to `bun install`, but just in CI. Developers can continue to use npm, yarn, etc.

I also updated various GitHub Action steps to use the newer versions (e.g. `actions/checkout@v2` -> `actions/checkout@v4`)
