### PR TITLE
Upgrade actions CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,18 +14,12 @@ jobs:
           - "18"
           - "*"
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
-      - uses: actions/cache@v2
-        with:
-          path: ~/.npm
-          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-
       - run: npm ci
       - run: npm test
-      - uses: codecov/codecov-action@v1
+      - uses: codecov/codecov-action@v5
         with:
           name: Node.js ${{ matrix.node-version }}


### PR DESCRIPTION
Current action is failing on `Missing download info for actions/cache@v2`. There's some cache built into the newer `setup-node`, but the dependency caching doesn't make much difference for overall test perf to warrant trying to keep it in the workflow.