### PR TITLE
feat: support parameter patterns

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -192,6 +192,10 @@ Parameter names must be provided after `:` or `*`, and they must be a valid Java
 
 Parameter names can be wrapped in double quote characters, and this error means you forgot to close the quote character.
 
+### Unterminated parameter pattern
+
+Parameter patterns must be wrapped in parentheses, and this error means you forgot to close the parentheses.
+
 ### Express <= 4.x
 
 Path-To-RegExp breaks compatibility with Express <= `4.x` in the following ways:

--- a/Readme.md
+++ b/Readme.md
@@ -196,10 +196,6 @@ Parameter names can be wrapped in double quote characters, and this error means 
 
 Parameter patterns must be wrapped in parentheses, and this error means you forgot to close the parentheses.
 
-### Only '|' is allowed as a special character in patterns
-
-When defining a custom pattern for a parameter (e.g., `:id(<pattern>)`), only the pipe character (`|`) is allowed as a special character inside the pattern.
-
 ### Missing pattern
 
 When defining a custom pattern for a parameter (e.g., `:id(<pattern>)`), you must provide a pattern.

--- a/Readme.md
+++ b/Readme.md
@@ -192,9 +192,17 @@ Parameter names must be provided after `:` or `*`, and they must be a valid Java
 
 Parameter names can be wrapped in double quote characters, and this error means you forgot to close the quote character.
 
-### Unterminated parameter pattern
+### Unbalanced pattern
 
 Parameter patterns must be wrapped in parentheses, and this error means you forgot to close the parentheses.
+
+### Only '|' is allowed as a special character in patterns
+
+When defining a custom pattern for a parameter (e.g., `:id(<pattern>)`), only the pipe character (`|`) is allowed as a special character inside the pattern.
+
+### Missing pattern
+
+When defining a custom pattern for a parameter (e.g., `:id(<pattern>)`), you must provide a pattern.
 
 ### Express <= 4.x
 

--- a/src/cases.spec.ts
+++ b/src/cases.spec.ts
@@ -412,15 +412,6 @@ export const MATCH_TESTS: MatchTestSet[] = [
       { input: "/", expected: false },
     ],
   },
-  {
-    path: "/:foo(\\d)",
-    tests: [
-      { input: "/1", expected: { path: "/1", params: { foo: "1" } } },
-      { input: "/123", expected: false },
-      { input: "/", expected: false },
-      { input: "/foo", expected: false },
-    ],
-  },
 
   /**
    * Case-sensitive paths.

--- a/src/cases.spec.ts
+++ b/src/cases.spec.ts
@@ -401,7 +401,7 @@ export const MATCH_TESTS: MatchTestSet[] = [
   },
 
   /**
-   * Parameter patterns.
+   * Patterns
    */
   {
     path: "/:locale(de|en)",
@@ -410,6 +410,32 @@ export const MATCH_TESTS: MatchTestSet[] = [
       { input: "/en", expected: { path: "/en", params: { locale: "en" } } },
       { input: "/fr", expected: false },
       { input: "/", expected: false },
+    ],
+  },
+  {
+    path: "/:foo(\\\\d)",
+    tests: [
+      {
+        input: "/\\d",
+        expected: { path: "/\\d", params: { foo: "\\d" } },
+      },
+    ],
+  },
+  {
+    path: "/file.*ext(png|jpg)",
+    tests: [
+      {
+        input: "/file.png",
+        expected: { path: "/file.png", params: { ext: ["png"] } },
+      },
+      {
+        input: "/file.webp",
+        expected: false,
+      },
+      {
+        input: "/file.jpg",
+        expected: { path: "/file.jpg", params: { ext: ["jpg"] } },
+      },
     ],
   },
 

--- a/src/cases.spec.ts
+++ b/src/cases.spec.ts
@@ -100,6 +100,20 @@ export const PARSER_TESTS: ParserTestSet[] = [
       { type: "text", value: "stuff" },
     ]),
   },
+  {
+    path: "/:locale(de|en)",
+    expected: new TokenData([
+      { type: "text", value: "/" },
+      { type: "param", name: "locale", pattern: "de|en" },
+    ]),
+  },
+  {
+    path: "/:foo(a|b|c)",
+    expected: new TokenData([
+      { type: "text", value: "/" },
+      { type: "param", name: "foo", pattern: "a|b|c" },
+    ]),
+  },
 ];
 
 export const STRINGIFY_TESTS: StringifyTestSet[] = [
@@ -270,6 +284,16 @@ export const COMPILE_TESTS: CompileTestSet[] = [
       { input: { test: "123/xyz" }, expected: "/123/xyz" },
     ],
   },
+  {
+    path: "/:locale(de|en)",
+    tests: [
+      { input: undefined, expected: null },
+      { input: {}, expected: null },
+      { input: { locale: "de" }, expected: "/de" },
+      { input: { locale: "en" }, expected: "/en" },
+      { input: { locale: "fr" }, expected: "/fr" },
+    ],
+  },
 ];
 
 /**
@@ -373,6 +397,28 @@ export const MATCH_TESTS: MatchTestSet[] = [
           params: { test: "param%23" },
         },
       },
+    ],
+  },
+
+  /**
+   * Parameter patterns.
+   */
+  {
+    path: "/:locale(de|en)",
+    tests: [
+      { input: "/de", expected: { path: "/de", params: { locale: "de" } } },
+      { input: "/en", expected: { path: "/en", params: { locale: "en" } } },
+      { input: "/fr", expected: false },
+      { input: "/", expected: false },
+    ],
+  },
+  {
+    path: "/:foo(\\d)",
+    tests: [
+      { input: "/1", expected: { path: "/1", params: { foo: "1" } } },
+      { input: "/123", expected: false },
+      { input: "/", expected: false },
+      { input: "/foo", expected: false },
     ],
   },
 

--- a/src/index.bench.ts
+++ b/src/index.bench.ts
@@ -12,7 +12,6 @@ const PATHS: string[] = [
 
 const STATIC_PATH_MATCH = match("/user");
 const SIMPLE_PATH_MATCH = match("/user/:id");
-const SIMPLE_PATH_MATCH_WITH_PATTERN = match("/user/:id(\\d+)");
 const MULTI_SEGMENT_MATCH = match("/:x/:y");
 const MULTI_PATTERN_MATCH = match("/:x-:y");
 const TRICKY_PATTERN_MATCH = match("/:foo|:bar|");
@@ -24,10 +23,6 @@ bench("static path", () => {
 
 bench("simple path", () => {
   for (const path of PATHS) SIMPLE_PATH_MATCH(path);
-});
-
-bench("simple path with parameter pattern", () => {
-  for (const path of PATHS) SIMPLE_PATH_MATCH_WITH_PATTERN(path);
 });
 
 bench("multi segment", () => {

--- a/src/index.bench.ts
+++ b/src/index.bench.ts
@@ -12,6 +12,7 @@ const PATHS: string[] = [
 
 const STATIC_PATH_MATCH = match("/user");
 const SIMPLE_PATH_MATCH = match("/user/:id");
+const SIMPLE_PATH_MATCH_WITH_PATTERN = match("/user/:id(\\d+)");
 const MULTI_SEGMENT_MATCH = match("/:x/:y");
 const MULTI_PATTERN_MATCH = match("/:x-:y");
 const TRICKY_PATTERN_MATCH = match("/:foo|:bar|");
@@ -23,6 +24,10 @@ bench("static path", () => {
 
 bench("simple path", () => {
   for (const path of PATHS) SIMPLE_PATH_MATCH(path);
+});
+
+bench("simple path with parameter pattern", () => {
+  for (const path of PATHS) SIMPLE_PATH_MATCH_WITH_PATTERN(path);
 });
 
 bench("multi segment", () => {

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -50,6 +50,14 @@ describe("path-to-regexp", () => {
         ),
       );
     });
+
+    it("should throw on unterminated parameter pattern", () => {
+      expect(() => parse("/:foo((bar")).toThrow(
+        new TypeError(
+          "Unterminated parameter pattern at 10: https://git.new/pathToRegexpError",
+        ),
+      );
+    });
   });
 
   describe("compile errors", () => {

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -51,10 +51,26 @@ describe("path-to-regexp", () => {
       );
     });
 
-    it("should throw on unterminated parameter pattern", () => {
-      expect(() => parse("/:foo((bar")).toThrow(
+    it("should throw on unbalanced pattern", () => {
+      expect(() => parse("/:foo((bar|sdfsdf)/")).toThrow(
         new TypeError(
-          "Unterminated parameter pattern at 10: https://git.new/pathToRegexpError",
+          "Unbalanced pattern at 5: https://git.new/pathToRegexpError",
+        ),
+      );
+    });
+
+    it("should throw on not allowed characters in pattern", () => {
+      expect(() => parse("/:foo(\\d)")).toThrow(
+        new TypeError(
+          `Only "|" is allowed as a special character in patterns at 6: https://git.new/pathToRegexpError`,
+        ),
+      );
+    });
+
+    it("should throw on missing pattern", () => {
+      expect(() => parse("//:foo()")).toThrow(
+        new TypeError(
+          "Missing pattern at 6: https://git.new/pathToRegexpError",
         ),
       );
     });

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { parse, compile, match, stringify } from "./index.js";
+import { parse, compile, match, stringify, pathToRegexp } from "./index.js";
 import {
   PARSER_TESTS,
   COMPILE_TESTS,
@@ -59,14 +59,6 @@ describe("path-to-regexp", () => {
       );
     });
 
-    it("should throw on not allowed characters in pattern", () => {
-      expect(() => parse("/:foo(\\d)")).toThrow(
-        new TypeError(
-          `Only "|" is allowed as a special character in patterns at 6: https://git.new/pathToRegexpError`,
-        ),
-      );
-    });
-
     it("should throw on missing pattern", () => {
       expect(() => parse("//:foo()")).toThrow(
         new TypeError(
@@ -115,6 +107,14 @@ describe("path-to-regexp", () => {
       expect(() => {
         toPath({ foo: [1, "a"] as any });
       }).toThrow(new TypeError('Expected "foo/0" to be a string'));
+    });
+  });
+
+  describe("pathToRegexp errors", () => {
+    it("should throw on not allowed characters in pattern", () => {
+      expect(() => pathToRegexp("/:foo(\\d)")).toThrow(
+        new TypeError(`Only "|" meta character is allowed in pattern: \\d`),
+      );
     });
   });
 


### PR DESCRIPTION
I'm planning to move to the newer version of path-to-regexp. In our codebase heavily relies on regex for parameter validation, especially in some legacy components we still have running in production.

I stumbled across [this comment](https://github.com/pillarjs/path-to-regexp/issues/223#issuecomment-2386812589) that mentions parameter pattern support might be coming in future versions. Based on that, I went ahead and implemented the functionality in this PR.

Feel free to ignore this PR if it doesn't align with the project's direction. I understand you may have different plans for handling parameter patterns in future versions!
