### PR TITLE
Escape text should escape backslash

### DIFF
--- a/src/cases.spec.ts
+++ b/src/cases.spec.ts
@@ -136,6 +136,16 @@ export const PARSER_TESTS: ParserTestSet[] = [
       '/:"test"stuff',
     ),
   },
+  {
+    path: "\\\\:test",
+    expected: new TokenData(
+      [
+        { type: "text", value: "\\" },
+        { type: "param", name: "test" },
+      ],
+      "\\\\:test",
+    ),
+  },
 ];
 
 export const STRINGIFY_TESTS: StringifyTestSet[] = [
@@ -203,6 +213,13 @@ export const STRINGIFY_TESTS: StringifyTestSet[] = [
       { type: "text", value: "stuff" },
     ]),
     expected: '/:"test"stuff',
+  },
+  {
+    data: new TokenData([
+      { type: "text", value: "\\" },
+      { type: "param", name: "test" },
+    ]),
+    expected: "\\\\:test",
   },
 ];
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -102,7 +102,7 @@ const SIMPLE_TOKENS: Record<string, TokenType> = {
  * Escape text for stringify to path.
  */
 function escapeText(str: string) {
-  return str.replace(/[{}()\[\]+?!:*]/g, "\\$&");
+  return str.replace(/[{}()\[\]+?!:*\\]/g, "\\$&");
 }
 
 /**


### PR DESCRIPTION
Fixes an issue where backslashes in text wouldn't be escaped if using the `stringify` method.