### PR TITLE
Remove engines from package

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,9 +44,6 @@
     "typescript": "^5.7.3",
     "vitest": "^3.0.5"
   },
-  "engines": {
-    "node": ">=18"
-  },
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
Engines was bumped in https://github.com/pillarjs/path-to-regexp/pull/348 to support the latest vitest version, removing the engines field instead to release a new minor with the changes on main. I could alternatively revert to `>=16` but I don't want it out of sync with CI or to figure out how to downgrade vitest for this.