### PR TITLE
Move parameter name errors up in docs

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -178,31 +178,31 @@ fn("/test"); //=> { path: '/test', index: 0, params: { foo: 'test' } }
 
 An effort has been made to ensure ambiguous paths from previous releases throw an error. This means you might be seeing an error when things worked before.
 
+### Missing parameter name
+
+Parameter names must be provided after `:` or `*`, for example `/*path`. They can be valid JavaScript identifiers (e.g. `:myName`) or JSON strings (`:"my-name"`).
+
 ### Unexpected `?` or `+`
 
 In past releases, `?`, `*`, and `+` were used to denote optional or repeating parameters. As an alternative, try these:
 
-- For optional (`?`), use an empty segment in a group such as `/:file{.:ext}`.
-- For repeating (`+`), only wildcard matching is supported, such as `/*path`.
-- For optional repeating (`*`), use a group and a wildcard parameter such as `/files{/*path}`.
+- For optional (`?`), use braces: `/file{.:ext}`.
+- For one or more (`+`), use a wildcard: `/*path`.
+- For zero or more (`*`), use both: `/files{/*path}`.
 
 ### Unexpected `(`, `)`, `[`, `]`, etc.
 
-Previous versions of Path-to-RegExp used these for RegExp features. This version no longer supports them so they've been reserved to avoid ambiguity. To use these characters literally, escape them with a backslash, e.g. `"\\("`.
-
-### Missing parameter name
-
-Parameter names must be provided after `:` or `*`, and they must be a valid JavaScript identifier. If you want an parameter name that isn't a JavaScript identifier, such as starting with a number, you can wrap the name in quotes like `:"my-name"`.
+Previous versions of Path-to-RegExp used these for RegExp features. This version no longer supports them so they've been reserved to avoid ambiguity. To match these characters literally, escape them with a backslash, e.g. `"\\("`.
 
 ### Unterminated quote
 
-Parameter names can be wrapped in double quote characters, and this error means you forgot to close the quote character.
+Parameter names can be wrapped in double quote characters, and this error means you forgot to close the quote character. For example, `:"foo`.
 
 ### Express <= 4.x
 
 Path-To-RegExp breaks compatibility with Express <= `4.x` in the following ways:
 
-- The wildcard `*` must have a name, matching the behavior of parameters `:`.
+- The wildcard `*` must have a name and matches the behavior of parameters `:`.
 - The optional character `?` is no longer supported, use braces instead: `/:file{.:ext}`.
 - Regexp characters are not supported.
 - Some characters have been reserved to avoid confusion during upgrade (`()[]?+!`).


### PR DESCRIPTION
The `/*` issue seems to be the most common, move it up and trying to make it more clear. Open to feedback on phrasing or rewriting the sentences entirely.