### PR TITLE
Add parsing to benchmarks

### DIFF
--- a/src/index.bench.ts
+++ b/src/index.bench.ts
@@ -1,42 +1,59 @@
-import { bench } from "vitest";
-import { match } from "./index.js";
+import { describe, bench } from "vitest";
+import { match, parse } from "./index.js";
 
-const PATHS: string[] = [
-  "/xyz",
-  "/user",
-  "/user/123",
-  "/" + "a".repeat(32_000),
-  "/-" + "-a".repeat(8_000) + "/-",
-  "/||||\x00|" + "||".repeat(27387) + "|\x00".repeat(27387) + "/||/",
-];
+describe("parse", () => {
+  const PATHS: string[] = [
+    "/api",
+    "/user/:id",
+    "/files/*filepath",
+    "/:foo-:bar",
+    '/quoted-:"param"',
+    "/complex/:param1-:param2/*rest",
+  ];
 
-const STATIC_PATH_MATCH = match("/user");
-const SIMPLE_PATH_MATCH = match("/user/:id");
-const MULTI_SEGMENT_MATCH = match("/:x/:y");
-const MULTI_PATTERN_MATCH = match("/:x-:y");
-const TRICKY_PATTERN_MATCH = match("/:foo|:bar|");
-const ASTERISK_MATCH = match("/*foo");
-
-bench("static path", () => {
-  for (const path of PATHS) STATIC_PATH_MATCH(path);
+  bench("parsing paths", () => {
+    for (const path of PATHS) parse(path);
+  });
 });
 
-bench("simple path", () => {
-  for (const path of PATHS) SIMPLE_PATH_MATCH(path);
-});
+describe("match", () => {
+  const PATHS: string[] = [
+    "/xyz",
+    "/user",
+    "/user/123",
+    "/" + "a".repeat(32_000),
+    "/-" + "-a".repeat(8_000) + "/-",
+    "/||||\x00|" + "||".repeat(27387) + "|\x00".repeat(27387) + "/||/",
+  ];
 
-bench("multi segment", () => {
-  for (const path of PATHS) MULTI_SEGMENT_MATCH(path);
-});
+  const STATIC_PATH_MATCH = match("/user");
+  const SIMPLE_PATH_MATCH = match("/user/:id");
+  const MULTI_SEGMENT_MATCH = match("/:x/:y");
+  const MULTI_PATTERN_MATCH = match("/:x-:y");
+  const TRICKY_PATTERN_MATCH = match("/:foo|:bar|");
+  const ASTERISK_MATCH = match("/*foo");
 
-bench("multi pattern", () => {
-  for (const path of PATHS) MULTI_PATTERN_MATCH(path);
-});
+  bench("static path", () => {
+    for (const path of PATHS) STATIC_PATH_MATCH(path);
+  });
 
-bench("tricky pattern", () => {
-  for (const path of PATHS) TRICKY_PATTERN_MATCH(path);
-});
+  bench("simple path", () => {
+    for (const path of PATHS) SIMPLE_PATH_MATCH(path);
+  });
 
-bench("asterisk", () => {
-  for (const path of PATHS) ASTERISK_MATCH(path);
+  bench("multi segment", () => {
+    for (const path of PATHS) MULTI_SEGMENT_MATCH(path);
+  });
+
+  bench("multi pattern", () => {
+    for (const path of PATHS) MULTI_PATTERN_MATCH(path);
+  });
+
+  bench("tricky pattern", () => {
+    for (const path of PATHS) TRICKY_PATTERN_MATCH(path);
+  });
+
+  bench("asterisk", () => {
+    for (const path of PATHS) ASTERISK_MATCH(path);
+  });
 });


### PR DESCRIPTION
Adding due to https://github.com/pillarjs/path-to-regexp/pull/416, making it clearer that there's match vs parse benchmarks.

```
 ✓ src/index.bench.ts > parse 672ms
     name                   hz     min     max    mean     p75     p99    p995    p999     rme  samples
   · parsing paths  381,719.82  0.0023  1.8449  0.0026  0.0025  0.0035  0.0050  0.0565  ±1.04%   190860
```