### PR TITLE
Simplify match patterns

### DIFF
--- a/src/cases.spec.ts
+++ b/src/cases.spec.ts
@@ -845,7 +845,7 @@ export const MATCH_TESTS: MatchTestSet[] = [
         input: "/route.html.json",
         expected: {
           path: "/route.html.json",
-          params: { test: "route.html", format: "json" },
+          params: { test: "route", format: "html.json" },
         },
       },
     ],
@@ -868,7 +868,7 @@ export const MATCH_TESTS: MatchTestSet[] = [
         input: "/route.json.html",
         expected: {
           path: "/route.json.html",
-          params: { test: "route.json", format: "html" },
+          params: { test: "route", format: "json.html" },
         },
       },
     ],
@@ -1561,7 +1561,7 @@ export const MATCH_TESTS: MatchTestSet[] = [
         input: "/123abcabc",
         expected: {
           path: "/123abcabc",
-          params: { foo: "123abcabc" },
+          params: { foo: "123", bar: "abc" },
         },
       },
     ],
@@ -1586,7 +1586,10 @@ export const MATCH_TESTS: MatchTestSet[] = [
       },
       {
         input: "/123abcabc",
-        expected: false,
+        expected: {
+          path: "/123abcabc",
+          params: { foo: "123", bar: "abc" },
+        },
       },
     ],
   },
@@ -2067,6 +2070,18 @@ export const MATCH_TESTS: MatchTestSet[] = [
       },
     ],
   },
+  {
+    path: "/:a-:b^*c@*d%:e",
+    tests: [
+      {
+        input: "/a-b^c@d%e",
+        expected: {
+          path: "/a-b^c@d%e",
+          params: { a: "a", b: "b", c: ["c"], d: ["d"], e: "e" },
+        },
+      },
+    ],
+  },
 
   /**
    * Multi character delimiters.
@@ -2121,7 +2136,7 @@ export const MATCH_TESTS: MatchTestSet[] = [
         input: "%25555....222%25",
         expected: {
           path: "%25555....222%25",
-          params: { foo: "555.", bar: ".222" },
+          params: { foo: "555", bar: "..222" },
         },
       },
     ],

--- a/src/index.ts
+++ b/src/index.ts
@@ -572,25 +572,14 @@ function toRegExpSource(
   let hasSegmentCapture = 0;
   let index = 0;
 
-  function hasInSegment(index: number, type: TokenType) {
-    while (index < tokens.length) {
-      const token = tokens[index++];
-      if (token.type === type) return true;
-      if (token.type === "text") {
-        if (token.value.includes(delimiter)) break;
-      }
-    }
-    return false;
-  }
-
-  function peekText(index: number) {
+  function peek(index: number): [string, Parameter | Wildcard | undefined] {
     let result = "";
     while (index < tokens.length) {
       const token = tokens[index++];
-      if (token.type !== "text") break;
+      if (token.type !== "text") return [result, token];
       result += token.value;
     }
-    return result;
+    return [result, undefined];
   }
 
   while (index < tokens.length) {
@@ -613,26 +602,32 @@ function toRegExpSource(
       }
 
       if (token.type === "param") {
-        result.push({
-          source: hasSegmentCapture // Seen param/wildcard in segment.
-            ? `(${negate(delimiter, backtrack)}+?)`
-            : hasInSegment(index, "wildcard") // See wildcard later in segment.
-              ? `(${negate(delimiter, peekText(index))}+?)`
-              : `(${negate(delimiter, "")}+?)`,
-          key: token,
-        });
+        if (hasSegmentCapture & 2) {
+          result.push({
+            source: `(${negate(delimiter, backtrack)}+)`,
+            key: token,
+          });
+        } else {
+          const [nextText, nextToken] = peek(index);
+
+          result.push({
+            source:
+              !nextToken || nextText.includes(delimiter)
+                ? `(${negate(delimiter, "")}+)`
+                : `(${negate(delimiter, nextText)}+|${escape(nextText)})`,
+            key: token,
+          });
+        }
 
         hasSegmentCapture |= prevCaptureType = 1;
       } else {
         result.push({
           source:
             hasSegmentCapture & 2 // Seen wildcard in segment.
-              ? `(${negate(backtrack, "")}+?)`
-              : hasSegmentCapture & 1 // Seen param in segment.
-                ? `(${negate(wildcardBacktrack, "")}+?)`
-                : wildcardBacktrack // No capture in segment, seen wildcard in path.
-                  ? `(${negate(wildcardBacktrack, "")}+?|${negate(delimiter, "")}+?)`
-                  : `([^]+?)`,
+              ? `(${negate("", backtrack)}+)`
+              : wildcardBacktrack // No capture in segment, seen wildcard in path.
+                ? `(${negate("", wildcardBacktrack)}+|${negate(delimiter, "")}+)`
+                : `([^]+?)`,
           key: token,
         });
 


### PR DESCRIPTION
Opening for posterity/interest, but unlikely to land due to the breaking change from the first parameter to the last being greedy. It is a much simpler solution to handle backtracking protection though, as you just always restrict forward until you hit a wildcard, then restrict backward.