### PR TITLE
Change to allow backtrack single match

### DIFF
--- a/src/cases.spec.ts
+++ b/src/cases.spec.ts
@@ -2070,6 +2070,18 @@ export const MATCH_TESTS: MatchTestSet[] = [
       },
     ],
   },
+  {
+    path: "/:a-:b^*c@*d%:e",
+    tests: [
+      {
+        input: "/a-b^c@d%e",
+        expected: {
+          path: "/a-b^c@d%e",
+          params: { a: "a", b: "b", c: ["c"], d: ["d"], e: "e" },
+        },
+      },
+    ],
+  },
 
   /**
    * Multi character delimiters.

--- a/src/index.ts
+++ b/src/index.ts
@@ -617,10 +617,10 @@ function toRegExpSource(
           source:
             hasSegmentCapture & 2 // Seen wildcard in segment.
               ? `(${negate(delimiter, backtrack)}+)`
-              : hasSegmentCapture & 1 // Seen parameter in segment.
-                ? `(${negate(delimiter, backtrack)}+|${escape(backtrack)})`
-                : hasInSegment(index, "wildcard") // See wildcard later in segment.
-                  ? `(${negate(delimiter, peekText(index))}+)`
+              : hasInSegment(index, "wildcard") // See wildcard later in segment.
+                ? `(${negate(delimiter, peekText(index))}+)`
+                : hasSegmentCapture & 1 // Seen parameter in segment.
+                  ? `(${negate(delimiter, backtrack)}+|${escape(backtrack)})`
                   : `(${negate(delimiter, "")}+?)`,
           key: token,
         });


### PR DESCRIPTION
Fixes a couple of the tests I found could be handled in https://github.com/pillarjs/path-to-regexp/pull/426 but without any breaking changes on which parameter is greedy.