### PR TITLE
test: add coverage for trailing option set to false

### DIFF
--- a/src/cases.spec.ts
+++ b/src/cases.spec.ts
@@ -479,6 +479,109 @@ export const MATCH_TESTS: MatchTestSet[] = [
   },
 
   /**
+   * Strict trailing delimiter.
+   */
+  {
+    path: "/test",
+    options: {
+      trailing: false,
+    },
+    tests: [
+      {
+        input: "/test",
+        expected: { path: "/test", params: {} },
+      },
+      { input: "/test/", expected: false },
+    ],
+  },
+  {
+    path: "/test/",
+    options: {
+      trailing: false,
+    },
+    tests: [
+      {
+        input: "/test/",
+        expected: { path: "/test/", params: {} },
+      },
+      { input: "/test", expected: false },
+    ],
+  },
+  {
+    path: "/:test",
+    options: {
+      trailing: false,
+    },
+    tests: [
+      {
+        input: "/route",
+        expected: { path: "/route", params: { test: "route" } },
+      },
+      { input: "/route/", expected: false },
+    ],
+  },
+  {
+    path: "/*path",
+    options: {
+      trailing: false,
+    },
+    tests: [
+      {
+        input: "/route",
+        expected: { path: "/route", params: { path: ["route"] } },
+      },
+      {
+        input: "/route/nested",
+        expected: {
+          path: "/route/nested",
+          params: { path: ["route", "nested"] },
+        },
+      },
+      {
+        input: "/route/nested/",
+        expected: {
+          path: "/route/nested/",
+          params: { path: ["route", "nested", ""] },
+        },
+      },
+    ],
+  },
+  {
+    path: "/test",
+    options: {
+      trailing: false,
+      end: false,
+    },
+    tests: [
+      {
+        input: "/test",
+        expected: { path: "/test", params: {} },
+      },
+      {
+        input: "/test/route",
+        expected: { path: "/test", params: {} },
+      },
+    ],
+  },
+  {
+    path: "{/:test}/bar",
+    options: {
+      trailing: false,
+    },
+    tests: [
+      {
+        input: "/bar",
+        expected: { path: "/bar", params: {} },
+      },
+      {
+        input: "/foo/bar",
+        expected: { path: "/foo/bar", params: { test: "foo" } },
+      },
+      { input: "/foo/bar/", expected: false },
+    ],
+  },
+
+  /**
    * Non-ending mode.
    */
   {


### PR DESCRIPTION
## What

Added test cases for the `trailing: false` option in `match()`, which previously had no test coverage.

## Why

While working with `path-to-regexp` in an Express API, I noticed the `trailing` option is documented and supported but had zero test cases when set to `false`. Every other match option (`end`, `sensitive`, `decode`, `delimiter`, `encodePath`) has dedicated test cases covering its behavior.

## Tests added

- **Static path** (`/test`): confirms trailing slash is rejected
- **Pattern with trailing slash** (`/test/`): confirms it requires the trailing slash
- **Parameterized path** (`/:test`): verifies params still work correctly
- **Wildcard path** (`/*path`): verifies wildcard captures with trailing delimiter behavior  
- **Combined `trailing: false` + `end: false`**: verifies both options interact correctly
- **Optional group** (`{/:test}/bar`): verifies trailing slash rejection with optional segments

All existing tests continue to pass.