### PR TITLE
docs: fix incorrect token type in custom path example

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -153,7 +153,7 @@ The `parse` function accepts a string and returns `TokenData`, which can be used
 
 `TokenData` has two properties:
 
-- **tokens** A sequence of tokens, currently of types `text`, `parameter`, `wildcard`, or `group`.
+- **tokens** A sequence of tokens, currently of types `text`, `param`, `wildcard`, or `group`.
 - **originalPath** The original path used with `parse`, shown in error messages to assist debugging.
 
 ### Custom path
@@ -165,13 +165,13 @@ import { match } from "path-to-regexp";
 
 const tokens = [
   { type: "text", value: "/" },
-  { type: "parameter", name: "foo" },
+  { type: "param", name: "foo" },
 ];
 const originalPath = "/[foo]"; // To help debug error messages.
 const path = { tokens, originalPath };
 const fn = match(path);
 
-fn("/test"); //=> { path: '/test', index: 0, params: { foo: 'test' } }
+fn("/test"); //=> { path: '/test', params: { foo: 'test' } }
 ```
 
 ## Errors


### PR DESCRIPTION
## What

Fixed two issues in the custom path example in the README:

1. Token type `"parameter"` → `"param"` 
2. Removed non-existent `index: 0` from the expected match output

## Why

The current example throws `Unknown token type: parameter` when copy-pasted and run, because the actual token type value is `"param"`, not `"parameter"`. The token types listed in the Tokens section also referenced `parameter` instead of `param`.

The expected output also included `index: 0` which is not part of the `MatchResult` interface — it only contains `path` and `params`.

```js
// Before (broken)
{ type: "parameter", name: "foo" }
fn("/test"); //=> { path: '/test', index: 0, params: { foo: 'test' } }

// After (works)
{ type: "param", name: "foo" }
fn("/test"); //=> { path: '/test', params: { foo: 'test' } }
```