### PR TITLE
Error on trailing backslash

### DIFF
--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -80,25 +80,25 @@ describe("path-to-regexp", () => {
 
     it("should throw on eol backslash", () => {
       expect(() => parse("/foo\\")).toThrow(
-        new PathError("Unexpected end after \\ at index 4", "/foo\\"),
+        new PathError("Unexpected end after \\ at index 5", "/foo\\"),
       );
     });
 
     it("should throw on eol backslash in group", () => {
       expect(() => parse("/foo/{bar\\")).toThrow(
-        new PathError("Unexpected end after \\ at index 9", "/foo/{bar\\"),
+        new PathError("Unexpected end after \\ at index 10", "/foo/{bar\\"),
       );
     });
 
     it("should throw on eol backslash after param", () => {
       expect(() => parse("/foo/:bar\\")).toThrow(
-        new PathError("Unexpected end after \\ at index 9", "/foo/:bar\\"),
+        new PathError("Unexpected end after \\ at index 10", "/foo/:bar\\"),
       );
     });
 
     it("should throw on eol backslash after wildcard", () => {
       expect(() => parse("/foo/*bar\\")).toThrow(
-        new PathError("Unexpected end after \\ at index 9", "/foo/*bar\\"),
+        new PathError("Unexpected end after \\ at index 10", "/foo/*bar\\"),
       );
     });
 

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -19,7 +19,7 @@ import {
  * Dynamically generate the entire test suite.
  */
 describe("path-to-regexp", () => {
-  describe("ParseError", () => {
+  describe("PathError", () => {
     it("should contain original path and debug url", () => {
       const error = new PathError(
         "Unexpected end at index 7, expected }",
@@ -75,6 +75,36 @@ describe("path-to-regexp", () => {
     it("should throw on unterminated quote", () => {
       expect(() => parse('/:"foo')).toThrow(
         new PathError("Unterminated quote at index 2", '/:"foo'),
+      );
+    });
+
+    it("should throw on eol backslash", () => {
+      expect(() => parse("/foo\\")).toThrow(
+        new PathError("Unexpected end after \\ at index 4", "/foo\\"),
+      );
+    });
+
+    it("should throw on eol backslash in group", () => {
+      expect(() => parse("/foo/{bar\\")).toThrow(
+        new PathError("Unexpected end after \\ at index 9", "/foo/{bar\\"),
+      );
+    });
+
+    it("should throw on eol backslash after param", () => {
+      expect(() => parse("/foo/:bar\\")).toThrow(
+        new PathError("Unexpected end after \\ at index 9", "/foo/:bar\\"),
+      );
+    });
+
+    it("should throw on eol backslash after wildcard", () => {
+      expect(() => parse("/foo/*bar\\")).toThrow(
+        new PathError("Unexpected end after \\ at index 9", "/foo/*bar\\"),
+      );
+    });
+
+    it("should throw on eol backslash in quoted param", () => {
+      expect(() => parse('/foo/:"bar\\')).toThrow(
+        new PathError("Unterminated quote at index 6", '/foo/:"bar\\'),
       );
     });
   });

--- a/src/index.ts
+++ b/src/index.ts
@@ -221,10 +221,7 @@ export function parse(str: string, options: ParseOptions = {}): TokenData {
 
     if (value === "\\") {
       if (index === chars.length) {
-        throw new PathError(
-          `Unexpected end after \\ at index ${index - 1}`,
-          str,
-        );
+        throw new PathError(`Unexpected end after \\ at index ${index}`, str);
       }
 
       tokens.push({ type: "char", index, value: chars[index++] });

--- a/src/index.ts
+++ b/src/index.ts
@@ -64,7 +64,6 @@ type TokenType =
   | "wildcard"
   | "param"
   | "char"
-  | "escape"
   | "end"
   // Reserved for use or ambiguous due to past use.
   | "("
@@ -220,10 +219,17 @@ export function parse(str: string, options: ParseOptions = {}): TokenData {
   while (index < chars.length) {
     const value = chars[index++];
 
-    if (SIMPLE_TOKENS.includes(value)) {
+    if (value === "\\") {
+      if (index === chars.length) {
+        throw new PathError(
+          `Unexpected end after \\ at index ${index - 1}`,
+          str,
+        );
+      }
+
+      tokens.push({ type: "char", index, value: chars[index++] });
+    } else if (SIMPLE_TOKENS.includes(value)) {
       tokens.push({ type: value as TokenType, index, value });
-    } else if (value === "\\") {
-      tokens.push({ type: "escape", index, value: chars[index++] });
     } else if (value === ":") {
       tokens.push({ type: "param", index, value: name() });
     } else if (value === "*") {
@@ -242,11 +248,11 @@ export function parse(str: string, options: ParseOptions = {}): TokenData {
       const token = tokens[pos++];
       if (token.type === endType) break;
 
-      if (token.type === "char" || token.type === "escape") {
+      if (token.type === "char") {
         let path = token.value;
         let cur = tokens[pos];
 
-        while (cur.type === "char" || cur.type === "escape") {
+        while (cur.type === "char") {
           path += cur.value;
           cur = tokens[++pos];
         }


### PR DESCRIPTION
Closes https://github.com/pillarjs/path-to-regexp/issues/433. Most straightforward approach that takes minimal bytes. 

An alternative might be to re-introduce the `consume` function that throws an error itself, and `tryConsume` token by token, but I removed that a while back to reduce bytes and function call overhead. The main difference would come down to the error message, which using a `tryConsume` style approach would hit the universal error message and print something like `Unexpected end at index 9, expected char` from:

```
Unexpected ${token.type} at index ${token.index}, expected ${endType}
```

I don't think adding the overhead back is worth it in this case, it's simpler to treat it as a one off error to handle.