### PR TITLE
Reintroduce ESM build with CJS compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,15 +17,25 @@
     "url": "https://opencollective.com/express"
   },
   "license": "MIT",
-  "exports": "./dist/index.js",
-  "main": "dist/index.js",
-  "typings": "dist/index.d.ts",
+  "exports": {
+    "import": {
+      "types": "./dist/index.d.mts",
+      "import": "./dist/index.mjs"
+    },
+    "require": {
+      "types": "./dist/index.d.ts",
+      "require": "./dist/index.js"
+    }
+  },
+  "main": "./dist/index.js",
+  "module": "./dist/index.mjs",
+  "types": "./dist/index.d.ts",
   "files": [
     "dist/"
   ],
   "scripts": {
     "bench": "vitest bench",
-    "build": "ts-scripts build",
+    "build": "tsdown src/index.ts --format cjs,esm --platform neutral --sourcemap",
     "format": "ts-scripts format",
     "lint": "ts-scripts lint",
     "prepare": "ts-scripts install && npm run build",
@@ -41,6 +51,7 @@
     "@vitest/coverage-v8": "^3.0.5",
     "recheck": "^4.5.0",
     "size-limit": "^11.1.2",
+    "tsdown": "^0.21.7",
     "typescript": "^5.7.3",
     "vitest": "^3.0.5"
   },
@@ -56,9 +67,6 @@
   "ts-scripts": {
     "dist": [
       "dist"
-    ],
-    "project": [
-      "tsconfig.build.json"
     ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -68,5 +68,10 @@
     "dist": [
       "dist"
     ]
+  },
+  "tsdown": {
+    "outputOptions": {
+      "esModule": true
+    }
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -667,3 +667,13 @@ function stringifyName(name: string, next: Token | undefined): string {
 
   return name;
 }
+
+export default {
+  PathError,
+  TokenData,
+  compile,
+  match,
+  parse,
+  pathToRegexp,
+  stringify,
+};

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,7 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "compilerOptions": {
-    "types": []
-  },
-  "exclude": ["src/**/*.spec.ts", "src/**/*.bench.ts"]
-}


### PR DESCRIPTION
Closes #346 
Fixes #347

This PR reintroduces an ESM build while preserving **CJS compatibility** for existing consumers.

The removal of the ESM build in v7 caused [tree-shaking issues](https://github.com/pillarjs/path-to-regexp/issues/347) and may have affected [adoption](https://majors.nullvoxpopuli.com/q?minors=false&old=false&packages=path-to-regexp).

It is done so with **utmost care for CJS compatibility**:
- `type` remains to be implied `commonjs`,
- `dist/index.js`, `dist/index.d.ts`, `index.js.map` are all there and remain to be CJS files,

ESM is introduced via `module` and `exports`. I leveraged [tsdown](https://tsdown.dev/), a zero-config bundler, that made this task easy and (hopefully) maintainable in the future.

Unlike #397, this does NOT make this package "ESM-first" which, I assume, was the main concern ultimately leading to the PR being closed. 

`@arethetypeswrong/cli` reports no issues:

```
 No problems found 🌟

┌───────────────────┬──────────────────┐
│                   │ "path-to-regexp" │
├───────────────────┼──────────────────┤
│ node10            │ 🟢               │
├───────────────────┼──────────────────┤
│ node16 (from CJS) │ 🟢 (CJS)         │
├───────────────────┼──────────────────┤
│ node16 (from ESM) │ 🟢 (ESM)         │
├───────────────────┼──────────────────┤
│ bundler           │ 🟢               │
└───────────────────┴──────────────────┘
```