### PR TITLE
Avoid duplicate trailing delimiter matches

### DIFF
--- a/src/cases.spec.ts
+++ b/src/cases.spec.ts
@@ -389,10 +389,7 @@ export const MATCH_TESTS: MatchTestSet[] = [
       },
       { input: "/route", expected: false },
       { input: "/test", expected: false },
-      {
-        input: "/test//",
-        expected: { path: "/test//", params: {} },
-      },
+      { input: "/test//", expected: false },
     ],
   },
   {
@@ -632,7 +629,7 @@ export const MATCH_TESTS: MatchTestSet[] = [
       },
       {
         input: "/test//",
-        expected: { path: "/test//", params: {} },
+        expected: { path: "/test/", params: {} },
       },
       {
         input: "/test/route",

--- a/src/index.ts
+++ b/src/index.ts
@@ -464,16 +464,14 @@ export function pathToRegexp(
     }
 
     const data = typeof path === "object" ? path : parse(path, options);
+    const originalPath = data.originalPath;
     flatten(data.tokens, 0, [], (tokens) => {
       if (combinations >= 256) {
-        throw new PathError("Too many path combinations", data.originalPath);
+        throw new PathError("Too many path combinations", originalPath);
       }
 
       if (combinations > 0) source += "|";
-      source += toRegExpSource(tokens, delimiter, keys, data.originalPath);
-      if (trailing && !tokensEndWithDelimiter(tokens, delimiter)) {
-        source += "(?:" + escape(delimiter) + "$)?";
-      }
+      source += toRegExpSource(tokens, delimiter, keys, originalPath, trailing);
       combinations++;
     });
   }
@@ -484,14 +482,6 @@ export function pathToRegexp(
   pattern += end ? "$" : "(?=" + escape(delimiter) + "|$)";
 
   return { regexp: new RegExp(pattern, sensitive ? "" : "i"), keys };
-}
-
-function tokensEndWithDelimiter(
-  tokens: Exclude<Token, Group>[],
-  delimiter: string,
-): boolean {
-  const last = tokens[tokens.length - 1];
-  return last?.type === "text" && last.value.endsWith(delimiter);
 }
 
 /**
@@ -529,6 +519,7 @@ function toRegExpSource(
   delimiter: string,
   keys: Keys,
   originalPath: string | undefined,
+  trailing: boolean,
 ): string {
   let result = "";
   let backtrack = "";
@@ -606,6 +597,10 @@ function toRegExpSource(
     }
 
     throw new TypeError(`Unknown token type: ${(token as any).type}`);
+  }
+
+  if (trailing && !backtrack.endsWith(delimiter)) {
+    result += "(?:" + escape(delimiter) + "$)?";
   }
 
   return result;

--- a/src/index.ts
+++ b/src/index.ts
@@ -471,6 +471,9 @@ export function pathToRegexp(
 
       if (combinations > 0) source += "|";
       source += toRegExpSource(tokens, delimiter, keys, data.originalPath);
+      if (trailing && !tokensEndWithDelimiter(tokens, delimiter)) {
+        source += "(?:" + escape(delimiter) + "$)?";
+      }
       combinations++;
     });
   }
@@ -478,10 +481,17 @@ export function pathToRegexp(
   process(path);
 
   let pattern = `^(?:${source})`;
-  if (trailing) pattern += "(?:" + escape(delimiter) + "$)?";
   pattern += end ? "$" : "(?=" + escape(delimiter) + "|$)";
 
   return { regexp: new RegExp(pattern, sensitive ? "" : "i"), keys };
+}
+
+function tokensEndWithDelimiter(
+  tokens: Exclude<Token, Group>[],
+  delimiter: string,
+): boolean {
+  const last = tokens[tokens.length - 1];
+  return last?.type === "text" && last.value.endsWith(delimiter);
 }
 
 /**


### PR DESCRIPTION
Fixes #441.

`pathToRegexp('/about/')` currently appends the optional trailing delimiter after a source that already ends in `/`, so the generated matcher accepts `/about//`. This moves the optional trailing delimiter into each flattened alternative and skips it when that alternative already ends with the configured delimiter.

Verification:
- `./node_modules/.bin/vitest run src/index.spec.ts -t '/test//'`
- `./node_modules/.bin/vitest run src/index.spec.ts`
- `npm run build`
- `npm run size`
- `git diff --check`

Note: I also attempted `npm test`; it reached 477 passing Vitest tests but the local ReDoS helper binary requires GLIBC_2.32/GLIBC_2.34 while this host has glibc 2.28, so that command exits with `recheck-linux-x64` EPIPE errors in this environment.
