### PR TITLE
fix: reject an empty-string param in compile

### DIFF
--- a/src/cases.spec.ts
+++ b/src/cases.spec.ts
@@ -271,6 +271,7 @@ export const COMPILE_TESTS: CompileTestSet[] = [
     tests: [
       { input: undefined, expected: null },
       { input: {}, expected: null },
+      { input: { test: "" }, expected: null },
       { input: { test: "123" }, expected: "/123" },
       { input: { test: "123/xyz" }, expected: "/123%2Fxyz" },
     ],

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -140,7 +140,7 @@ describe("path-to-regexp", () => {
 
       expect(() => {
         toPath({ foo: [] });
-      }).toThrow(new TypeError('Expected "foo" to be a string'));
+      }).toThrow(new TypeError('Expected "foo" to be a non-empty string'));
     });
 
     it("should throw when a wildcard is not an array", () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -373,11 +373,7 @@ function tokenToFunction(
       return "";
     }
 
-    if (typeof value !== "string") {
-      throw new TypeError(`Expected "${token.name}" to be a string`);
-    }
-
-    if (value === "") {
+    if (typeof value !== "string" || value.length === 0) {
       throw new TypeError(`Expected "${token.name}" to be a non-empty string`);
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -377,6 +377,10 @@ function tokenToFunction(
       throw new TypeError(`Expected "${token.name}" to be a string`);
     }
 
+    if (value === "") {
+      throw new TypeError(`Expected "${token.name}" to be a non-empty string`);
+    }
+
     return encodeValue(value);
   };
 }


### PR DESCRIPTION
## Problem

`compile()` accepted an empty-string value for a required param, producing an empty path segment instead of rejecting it. For example, `compile("/:test")({ test: "" })` returned `/` instead of throwing.

## Fix

Reject an empty (or non-string) param value with a single check that mirrors the existing array validation, throwing `Expected "<name>" to be a non-empty string`.

## Tests

Added a case asserting `{ test: "" }` throws, and updated the one existing test that asserted the old `to be a string` message.
