### PR TITLE
Fix stringify of param names with control characters

### DIFF
--- a/src/cases.spec.ts
+++ b/src/cases.spec.ts
@@ -222,6 +222,13 @@ export const STRINGIFY_TESTS: StringifyTestSet[] = [
     expected: "\\\\:test",
   },
   {
+    data: new TokenData([
+      { type: "text", value: "/" },
+      { type: "param", name: "a\nb" },
+    ]),
+    expected: '/:"a\nb"',
+  },
+  {
     data: {
       tokens: [
         { type: "text", value: "/" },

--- a/src/index.ts
+++ b/src/index.ts
@@ -656,13 +656,24 @@ export function stringify(data: TokenData): string {
 }
 
 /**
+ * Wrap a parameter name in quotes, escaping only the characters the parser
+ * treats specially inside a quoted name (`"` and `\`). `JSON.stringify` can't
+ * be used here because it emits escapes like `\n` that the parser reads back as
+ * the literal character `n`, so names with control characters wouldn't survive
+ * a `parse` -> `stringify` -> `parse` round trip.
+ */
+function quoteName(name: string): string {
+  return `"${name.replace(/["\\]/g, "\\$&")}"`;
+}
+
+/**
  * Stringify a parameter name, escaping when it cannot be emitted directly.
  */
 function stringifyName(name: string, next: Token | undefined): string {
-  if (!ID.test(name)) return JSON.stringify(name);
+  if (!ID.test(name)) return quoteName(name);
 
   if (next?.type === "text" && ID_CONTINUE.test(next.value[0])) {
-    return JSON.stringify(name);
+    return quoteName(name);
   }
 
   return name;


### PR DESCRIPTION
I was round-tripping token data and noticed names with a control char don't come back the same: `parse(stringify(parse(':"a\nb"')))` gives the name `anb` instead of `a\nb`.

The cause is that `stringifyName` falls back to `JSON.stringify` when a name can't be emitted bare. JSON escaping uses sequences like `\n`/`\t`/`\uXXXX`, but the parser's quoted-name handling only understands `\` as "next char literal" — so it reads `\n` back as the letter `n`. The parser happily accepts these names in the first place (e.g. `:"a<newline>b"`), so stringify should be able to reproduce them.

Switched to quoting that only escapes the two characters the parser treats specially inside quotes (`"` and `\`). For names that just needed wrapping (digits, dashes, etc.) the output is unchanged, since JSON already produced the same thing there. Added a stringify case for a name with a newline.