### PR TITLE
Escape quoted parameter names the way parse understands

### DIFF
--- a/src/cases.spec.ts
+++ b/src/cases.spec.ts
@@ -190,6 +190,20 @@ export const STRINGIFY_TESTS: StringifyTestSet[] = [
   },
   {
     data: new TokenData([
+      { type: "text", value: "/" },
+      { type: "param", name: "a\tb" },
+    ]),
+    expected: '/:"a\tb"',
+  },
+  {
+    data: new TokenData([
+      { type: "text", value: "/" },
+      { type: "param", name: 'a"b\\c' },
+    ]),
+    expected: '/:"a\\"b\\\\c"',
+  },
+  {
+    data: new TokenData([
       { type: "text", value: "/users" },
       {
         type: "group",

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -240,6 +240,11 @@ describe("path-to-regexp", () => {
         const path = stringify(data);
         expect(path).toEqual(expected);
       });
+
+      it("should parse back to the original tokens", () => {
+        const { tokens } = parse(stringify(data));
+        expect(tokens).toEqual(data.tokens);
+      });
     },
   );
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -659,11 +659,21 @@ export function stringify(data: TokenData): string {
  * Stringify a parameter name, escaping when it cannot be emitted directly.
  */
 function stringifyName(name: string, next: Token | undefined): string {
-  if (!ID.test(name)) return JSON.stringify(name);
+  if (!ID.test(name)) return quoteName(name);
 
   if (next?.type === "text" && ID_CONTINUE.test(next.value[0])) {
-    return JSON.stringify(name);
+    return quoteName(name);
   }
 
   return name;
+}
+
+/**
+ * Quote a parameter name using the escape rules understood by `parse`,
+ * which only recognizes a backslash as escaping the next character.
+ * `JSON.stringify` would emit escapes such as `\t` or `\uXXXX` that
+ * `parse` reads back as the literal characters `t` or `uXXXX`.
+ */
+function quoteName(name: string): string {
+  return `"${name.replace(/["\\]/g, "\\$&")}"`;
 }


### PR DESCRIPTION
`stringifyName` uses `JSON.stringify` to quote non-identifier parameter names, but `parse` only recognizes a backslash as escaping the next literal character. The two schemes agree for `\"` and `\\` — and diverge for every character JSON escapes into a sequence (`\t`, `\n`, `\uXXXX`, …), silently corrupting the round-trip:

```js
const a = parse(':"a\tb"'); // name === 'a\tb' (tab is legal inside quotes)
const s = stringify(a);      // ':"a\tb"'  (JSON-escaped)
const b = parse(s);          // name === 'atb'  ← backslash stripped, 't' kept
```

This changes which parameter a compiled/matched route produces, with no error anywhere.

The fix quotes names by escaping only `"` and `\` and emitting all other characters directly, which `parse` reads back unchanged.

Also adds stringify cases for a control character and quote/backslash in names, plus a round-trip assertion that `parse(stringify(data))` reproduces the original tokens for every stringify case — that assertion fails on `master` for the new cases and passes here.