### PR TITLE
fix: reject wildcard array that compiles to an empty path

### DIFF
--- a/src/cases.spec.ts
+++ b/src/cases.spec.ts
@@ -322,6 +322,7 @@ export const COMPILE_TESTS: CompileTestSet[] = [
       { input: undefined, expected: null },
       { input: {}, expected: null },
       { input: { test: [] }, expected: null },
+      { input: { test: [""] }, expected: null },
       { input: { test: ["123"] }, expected: "/123" },
       { input: { test: ["123", "xyz"] }, expected: "/123/xyz" },
     ],

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -158,6 +158,14 @@ describe("path-to-regexp", () => {
         toPath({ foo: [1, "a"] as any });
       }).toThrow(new TypeError('Expected "foo/0" to be a string'));
     });
+
+    it("should throw when a wildcard array yields an empty path", () => {
+      const toPath = compile("/*foo");
+
+      expect(() => {
+        toPath({ foo: [""] });
+      }).toThrow(new TypeError('Expected "foo" to be a non-empty array'));
+    });
   });
 
   describe("pathToRegexp errors", () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -362,6 +362,10 @@ function tokenToFunction(
         result += encodeValue(value[i]);
       }
 
+      if (!result) {
+        throw new TypeError(`Expected "${token.name}" to be a non-empty array`);
+      }
+
       return result;
     };
   }


### PR DESCRIPTION
`compile` for a wildcard accepts an array whose only content is empty, and silently returns a path the same pattern can never match:

```js
compile("/*foo")({ foo: [""] }); //=> "/"
match("/*foo")("/");             //=> false
```

The value is lost with no error. This is the array counterpart of the empty-string param case rejected in #444.

A wildcard's value domain is exactly what `match` produces — `capturedValue.split(delimiter)` — and `match` can never yield `[""]`, since the capture group requires at least one character. So there is no input for which `[""]` is a correct value; `compile` should reject it rather than emit an unmatchable path.

The fix throws when the joined output is empty. Arrays that contain empty segments but still produce content (e.g. `["a", ""]` → `"/a/"`, `["route", "nested", ""]` → `"/route/nested/"`) are what `match` returns for trailing/empty segments and continue to round-trip unchanged.

Adds a regression test.
