### PR TITLE
Match all remaining segments for a terminal wildcard after a bare delimiter

### DIFF
--- a/src/cases.spec.ts
+++ b/src/cases.spec.ts
@@ -1559,6 +1559,25 @@ export const MATCH_TESTS: MatchTestSet[] = [
     ],
   },
   {
+    path: "/*a/:b.:c/*d",
+    tests: [
+      {
+        input: "/x/name.ext/p/q/r",
+        expected: {
+          path: "/x/name.ext/p/q/r",
+          params: { a: ["x"], b: "name", c: "ext", d: ["p", "q", "r"] },
+        },
+      },
+      {
+        input: "/x/name.ext/p",
+        expected: {
+          path: "/x/name.ext/p",
+          params: { a: ["x"], b: "name", c: "ext", d: ["p"] },
+        },
+      },
+    ],
+  },
+  {
     path: "{*path}",
     tests: [
       {

--- a/src/index.ts
+++ b/src/index.ts
@@ -583,7 +583,13 @@ function toRegExpSource(
           hasSegmentCapture & 2 // Seen wildcard in segment.
             ? `(${negate(backtrack, "")}+)`
             : wildcardBacktrack // No capture in segment, seen wildcard in path.
-              ? `(${negate(wildcardBacktrack, "")}+|${negate(delimiter, "")}+)`
+              ? wildcardBacktrack === delimiter && index === tokens.length
+                ? // A terminal wildcard whose only separator from the previous
+                  // wildcard is the bare delimiter has no multi-character anchor
+                  // to bound it, so it must match all remaining segments. It is
+                  // `$`-anchored, so an unbounded class stays ReDoS-safe.
+                  `([^]+)`
+                : `(${negate(wildcardBacktrack, "")}+|${negate(delimiter, "")}+)`
               : `([^]+)`;
 
         wildcardBacktrack = "";


### PR DESCRIPTION
### Problem

A wildcard that follows an earlier wildcard is deliberately bounded to a single
segment (a ReDoS mitigation), using the fixed text emitted right after the
previous wildcard as an anchor. But when that separating text is only the
delimiter and a param segment sits between the two wildcards — e.g.
`/*a/:b.:c/*d` — `wildcardBacktrack === delimiter`, and the branch emits

```
([^/]+|[^/]+)
```

two **identical** single-segment classes, so the trailing wildcard captures only
one segment. A unique literal in the middle (the `.` in `:b.:c`) then prevents
the greedy leading wildcard from absorbing the surplus, so a valid multi-segment
path fails to match — and `compile()` produces a path its own `match()` rejects:

```js
const p = "/*a/:b.:c/*d";
match(p)("/x/name.ext/p/q/r");   // => false   (expected a match)
match(p)("/x/name.ext/p");       // => matches (single segment works)

compile(p)({ a: ["x"], b: "name", c: "ext", d: ["p", "q", "r"] });
// => "/x/name.ext/p/q/r"
match(p)("/x/name.ext/p/q/r");   // => false   (compile output unmatchable by its own pattern)
```

Express 5 depends on this library, so this is mis-routing of valid URLs.

### Fix

A **terminal** wildcard is `$`-anchored, so an unbounded `([^]+)` is ReDoS-safe
there. Special-case only the terminal + bare-delimiter collapse
(`wildcardBacktrack === delimiter && index === tokens.length`) → `([^]+)`.
Non-terminal wildcards keep the single-segment guard unchanged
(`/*a/:b/*c/:d` still compiles to `([^/]+|[^/]+)` for the middle wildcard).

### Verification

- Full suite green — **481 tests pass** (was 478), including the entire `redos`
  suite (`recheck` confirms the new `…\/([^]+))(?:\/$)?$` regexes are safe) and
  size-limit.
- Added `/*a/:b.:c/*d` match cases to `cases.spec.ts` (fail on `main`, pass with
  the fix).
- Byte-identical output for untouched shapes: `/*foo/:bar/*baz`,
  `/*a/:b/*c/:d` (non-terminal), multi-char anchors like `/*a/x-*b`.
