### PR TITLE
Refactor matching to be non-greedy

### DIFF
--- a/src/cases.spec.ts
+++ b/src/cases.spec.ts
@@ -1,8 +1,9 @@
+import { TestOptions } from "vitest";
+
 import {
   type MatchOptions,
   type Match,
   type ParseOptions,
-  type Token,
   type CompileOptions,
   type ParamData,
   TokenData,
@@ -37,6 +38,7 @@ export interface MatchTestSet {
     input: string;
     expected: Match<any>;
   }>;
+  testOptions?: TestOptions;
 }
 
 export const PARSER_TESTS: ParserTestSet[] = [
@@ -949,7 +951,7 @@ export const MATCH_TESTS: MatchTestSet[] = [
         input: "/route.html.json",
         expected: {
           path: "/route.html.json",
-          params: { test: "route.html", format: "json" },
+          params: { test: "route", format: "html.json" },
         },
       },
     ],
@@ -972,7 +974,7 @@ export const MATCH_TESTS: MatchTestSet[] = [
         input: "/route.json.html",
         expected: {
           path: "/route.json.html",
-          params: { test: "route.json", format: "html" },
+          params: { test: "route", format: "json.html" },
         },
       },
     ],
@@ -1553,7 +1555,7 @@ export const MATCH_TESTS: MatchTestSet[] = [
         input: "/1/2/3/4/5",
         expected: {
           path: "/1/2/3/4/5",
-          params: { foo: ["1", "2", "3"], bar: "4", baz: ["5"] },
+          params: { foo: ["1"], bar: "2", baz: ["3", "4", "5"] },
         },
       },
     ],
@@ -1580,10 +1582,10 @@ export const MATCH_TESTS: MatchTestSet[] = [
         expected: {
           path: "/x/y/z/name.ext/name2.ext2/p/q/r",
           params: {
-            a: ["x", "y", "z", "name.ext"],
-            b: "name2",
-            c: "ext2",
-            d: ["p", "q", "r"],
+            a: ["x", "y", "z"],
+            b: "name",
+            c: "ext",
+            d: ["name2.ext2", "p", "q", "r"],
           },
         },
       },
@@ -1599,10 +1601,10 @@ export const MATCH_TESTS: MatchTestSet[] = [
         expected: {
           path: "/x/x/name.ext/name.ext/x/x/",
           params: {
-            a: ["x", "x", "name.ext"],
+            a: ["x", "x"],
             b: "name",
             c: "ext",
-            d: ["x", "x", ""],
+            d: ["name.ext", "x", "x", ""],
           },
         },
       },
@@ -1611,10 +1613,10 @@ export const MATCH_TESTS: MatchTestSet[] = [
         expected: {
           path: "/x/x/name.ext//name.ext/x/x/",
           params: {
-            a: ["x", "x", "name.ext", ""],
+            a: ["x", "x"],
             b: "name",
             c: "ext",
-            d: ["x", "x", ""],
+            d: ["", "name.ext", "x", "x", ""],
           },
         },
       },
@@ -2022,7 +2024,7 @@ export const MATCH_TESTS: MatchTestSet[] = [
         input: "/a-b-c-d",
         expected: {
           path: "/a-b-c-d",
-          params: { foo: ["a-b"], bar: ["c"], baz: "d" },
+          params: { foo: ["a"], bar: ["b-c"], baz: "d" },
         },
       },
     ],
@@ -2045,7 +2047,7 @@ export const MATCH_TESTS: MatchTestSet[] = [
         input: "/a-b-c-d",
         expected: {
           path: "/a-b-c-d",
-          params: { foo: ["a-b"], bar: "c", baz: ["d"] },
+          params: { foo: ["a"], bar: "b", baz: ["c-d"] },
         },
       },
     ],
@@ -2079,11 +2081,11 @@ export const MATCH_TESTS: MatchTestSet[] = [
       },
       {
         input: "/a-b-",
-        expected: false,
+        expected: { path: "/a-b-", params: { foo: ["a"], bar: ["b-"] } },
       },
       {
         input: "/a-b-c-d",
-        expected: { path: "/a-b-c-d", params: { foo: ["a-b-c"], bar: ["d"] } },
+        expected: { path: "/a-b-c-d", params: { foo: ["a"], bar: ["b-c-d"] } },
       },
     ],
   },
@@ -2151,7 +2153,7 @@ export const MATCH_TESTS: MatchTestSet[] = [
         input: "/a/b/c/d/e",
         expected: {
           path: "/a/b/c/d/e",
-          params: { foo: ["a", "b"], bar: "c", baz: ["d"], qux: "e" },
+          params: { foo: ["a"], bar: "b", baz: ["c", "d"], qux: "e" },
         },
       },
     ],
@@ -2240,7 +2242,181 @@ export const MATCH_TESTS: MatchTestSet[] = [
         input: "/a-b-c.d.e@f@g",
         expected: {
           path: "/a-b-c.d.e@f@g",
-          params: { a: "a", b: ["b-c.d"], c: "e@f", d: ["g"] },
+          params: { a: "a", b: ["b-c.d"], c: "e", d: ["f@g"] },
+        },
+      },
+    ],
+  },
+  {
+    path: "/:a-.-*b",
+    tests: [
+      {
+        input: "/-.-.-x",
+        expected: {
+          path: "/-.-.-x",
+          params: { a: "-.", b: ["x"] },
+        },
+      },
+    ],
+  },
+  {
+    path: "/*a-:b",
+    tests: [
+      {
+        input: "/a--",
+        expected: { path: "/a--", params: { a: ["a"], b: "-" } },
+      },
+    ],
+  },
+  {
+    path: "/:a--*b",
+    tests: [
+      {
+        input: "/--x--y",
+        expected: {
+          path: "/--x--y",
+          params: { a: "--x", b: ["y"] },
+        },
+      },
+    ],
+  },
+  {
+    path: "/:a%25*b",
+    tests: [
+      {
+        input: "/%252%25x",
+        expected: {
+          path: "/%252%25x",
+          // Decodes `%25` to `%`.
+          params: { a: "%2", b: ["x"] },
+        },
+      },
+    ],
+  },
+  {
+    path: "/:a{%25*b}",
+    tests: [
+      {
+        input: "/%252%25x",
+        expected: {
+          path: "/%252%25x",
+          // Decodes `%25` to `%`.
+          params: { a: "%2", b: ["x"] },
+        },
+      },
+    ],
+  },
+  {
+    path: "/:a-:b/end",
+    tests: [
+      {
+        input: "/x-abc-/end",
+        expected: {
+          path: "/x-abc-/end",
+          params: { a: "x", b: "abc-" },
+        },
+      },
+    ],
+  },
+  {
+    path: "/*a.:b/end",
+    tests: [
+      {
+        input: "/x.abc./end",
+        expected: {
+          path: "/x.abc./end",
+          params: { a: ["x"], b: "abc." },
+        },
+      },
+      {
+        input: "/x.-./end",
+        expected: {
+          path: "/x.-./end",
+          params: { a: ["x"], b: "-." },
+        },
+      },
+    ],
+  },
+  {
+    path: "/:a%25:b/end",
+    tests: [
+      {
+        input: "/x%25abc%25/end",
+        expected: {
+          path: "/x%25abc%25/end",
+          params: { a: "x", b: "abc%" },
+        },
+      },
+    ],
+  },
+  {
+    path: "/:a--:b--:c",
+    tests: [
+      {
+        input: "/x-----y",
+        expected: {
+          path: "/x-----y",
+          params: { a: "x", b: "-", c: "y" },
+        },
+      },
+    ],
+  },
+  {
+    path: "/*a-:p.*b.:q",
+    tests: [
+      {
+        input: "/a-b.c.d",
+        expected: {
+          path: "/a-b.c.d",
+          params: { a: ["a"], p: "b", b: ["c"], q: "d" },
+        },
+      },
+    ],
+  },
+  {
+    path: "/*a-:p.*b.:q/end",
+    tests: [
+      {
+        input: "/a-b.c.d/end",
+        expected: {
+          path: "/a-b.c.d/end",
+          params: { a: ["a"], p: "b", b: ["c"], q: "d" },
+        },
+      },
+    ],
+  },
+  {
+    path: "/*a/:b~:c.*d",
+    tests: [
+      {
+        input: "/x/a~..z",
+        expected: {
+          path: "/x/a~..z",
+          params: { a: ["x"], b: "a", c: ".", d: ["z"] },
+        },
+      },
+    ],
+  },
+  {
+    path: "/*a-:p{.*b.:q}",
+    tests: [
+      {
+        input: "/a-b.c.d",
+        expected: {
+          path: "/a-b.c.d",
+          params: { a: ["a"], p: "b", b: ["c"], q: "d" },
+        },
+      },
+    ],
+  },
+  {
+    path: "/*a.:p--*b",
+    tests: [
+      {
+        input: "/a.b---",
+        expected: {
+          path: "/a.b---",
+          params: { a: ["a"], p: "b", b: ["-"] },
         },
       },
     ],
@@ -2260,7 +2436,14 @@ export const MATCH_TESTS: MatchTestSet[] = [
         input: "/a--b/c@@d--e@@f",
         expected: {
           path: "/a--b/c@@d--e@@f",
-          params: { a: ["a--b", "c@@d"], b: ["e"], c: "f" },
+          params: { a: ["a"], b: ["b", "c@@d--e"], c: "f" },
+        },
+      },
+      {
+        input: "/a/b@@c--d@@e",
+        expected: {
+          path: "/a/b@@c--d@@e",
+          params: { a: ["a", "b@@c"], b: ["d"], c: "e" },
         },
       },
     ],
@@ -2469,7 +2652,7 @@ export const MATCH_TESTS: MatchTestSet[] = [
         input: "%25555....222%25",
         expected: {
           path: "%25555....222%25",
-          params: { foo: "555..", bar: "222" },
+          params: { foo: "555", bar: "..222" },
         },
       },
     ],

--- a/src/cases.spec.ts
+++ b/src/cases.spec.ts
@@ -1587,6 +1587,37 @@ export const MATCH_TESTS: MatchTestSet[] = [
           },
         },
       },
+      {
+        input: "/x/x/name.ext/ext/x/x",
+        expected: {
+          path: "/x/x/name.ext/ext/x/x",
+          params: { a: ["x", "x"], b: "name", c: "ext", d: ["ext", "x", "x"] },
+        },
+      },
+      {
+        input: "/x/x/name.ext/name.ext/x/x/",
+        expected: {
+          path: "/x/x/name.ext/name.ext/x/x/",
+          params: {
+            a: ["x", "x", "name.ext"],
+            b: "name",
+            c: "ext",
+            d: ["x", "x", ""],
+          },
+        },
+      },
+      {
+        input: "/x/x/name.ext//name.ext/x/x/",
+        expected: {
+          path: "/x/x/name.ext//name.ext/x/x/",
+          params: {
+            a: ["x", "x", "name.ext", ""],
+            b: "name",
+            c: "ext",
+            d: ["x", "x", ""],
+          },
+        },
+      },
     ],
   },
   {

--- a/src/cases.spec.ts
+++ b/src/cases.spec.ts
@@ -1559,6 +1559,75 @@ export const MATCH_TESTS: MatchTestSet[] = [
     ],
   },
   {
+    path: "/*a/:b.:c/*d",
+    tests: [
+      {
+        input: "/x/name.ext/p/q/r",
+        expected: {
+          path: "/x/name.ext/p/q/r",
+          params: { a: ["x"], b: "name", c: "ext", d: ["p", "q", "r"] },
+        },
+      },
+      {
+        input: "/x/name.ext/p",
+        expected: {
+          path: "/x/name.ext/p",
+          params: { a: ["x"], b: "name", c: "ext", d: ["p"] },
+        },
+      },
+      {
+        input: "/x/y/z/name.ext/name2.ext2/p/q/r",
+        expected: {
+          path: "/x/y/z/name.ext/name2.ext2/p/q/r",
+          params: {
+            a: ["x", "y", "z", "name.ext"],
+            b: "name2",
+            c: "ext2",
+            d: ["p", "q", "r"],
+          },
+        },
+      },
+    ],
+  },
+  {
+    path: "/*a/_/:b.:c/*d",
+    tests: [
+      {
+        input: "/x/_/name.ext/p/q/r",
+        expected: {
+          path: "/x/_/name.ext/p/q/r",
+          params: { a: ["x"], b: "name", c: "ext", d: ["p", "q", "r"] },
+        },
+      },
+      {
+        input: "/x/_/name.ext/p",
+        expected: {
+          path: "/x/_/name.ext/p",
+          params: { a: ["x"], b: "name", c: "ext", d: ["p"] },
+        },
+      },
+    ],
+  },
+  {
+    path: "/*a/:b.:c/*d/",
+    tests: [
+      {
+        input: "/x/name.ext/p/q/r/",
+        expected: {
+          path: "/x/name.ext/p/q/r/",
+          params: { a: ["x"], b: "name", c: "ext", d: ["p", "q", "r"] },
+        },
+      },
+      {
+        input: "/x/name.ext/p/",
+        expected: {
+          path: "/x/name.ext/p/",
+          params: { a: ["x"], b: "name", c: "ext", d: ["p"] },
+        },
+      },
+    ],
+  },
+  {
     path: "{*path}",
     tests: [
       {
@@ -2424,6 +2493,25 @@ export const MATCH_TESTS: MatchTestSet[] = [
         expected: {
           path: "/x/foo/y-/bar/w",
           params: { a: ["foo"], b: ["bar"] },
+        },
+      },
+    ],
+  },
+  {
+    path: ["/x/*a/:b.:c/*d/z", "/x/*a/:b.:c/*d/w"],
+    tests: [
+      {
+        input: "/x/foo/name.ext/bar/z",
+        expected: {
+          path: "/x/foo/name.ext/bar/z",
+          params: { a: ["foo"], b: "name", c: "ext", d: ["bar"] },
+        },
+      },
+      {
+        input: "/x/foo/name.ext/bar/w",
+        expected: {
+          path: "/x/foo/name.ext/bar/w",
+          params: { a: ["foo"], b: "name", c: "ext", d: ["bar"] },
         },
       },
     ],

--- a/src/cases.spec.ts
+++ b/src/cases.spec.ts
@@ -2598,6 +2598,21 @@ export const MATCH_TESTS: MatchTestSet[] = [
       },
     ],
   },
+  {
+    path: "1*a\\1*b",
+    options: {
+      delimiter: "1",
+    },
+    tests: [
+      {
+        input: "1x1y",
+        expected: {
+          path: "1x1y",
+          params: { a: ["x"], b: ["y"] },
+        },
+      },
+    ],
+  },
 
   /**
    * Multi character delimiters.

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -260,11 +260,15 @@ describe("path-to-regexp", () => {
 
   describe.each(MATCH_TESTS)(
     "match $path with $options",
-    ({ path, options, tests }) => {
-      it.each(tests)("should match $input", ({ input, expected }) => {
-        const fn = match(path, options);
-        expect(fn(input)).toEqual(expected);
-      });
+    ({ path, options, tests, testOptions }) => {
+      it.each(tests)(
+        "should match $input",
+        testOptions ?? {},
+        ({ input, expected }) => {
+          const fn = match(path, options);
+          expect(fn(input)).toEqual(expected);
+        },
+      );
     },
   );
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -528,13 +528,10 @@ function toRegExpSource(
   let wildcardBacktrack = "";
   let index = 0;
 
-  function seekWildcard(index: number, stopOnSegment = false) {
+  function seekWildcard(index: number) {
     while (index < tokens.length) {
       const token = tokens[index++];
       if (token.type === "wildcard") return true;
-      if (stopOnSegment && token.type === "text") {
-        if (token.value.includes(delimiter)) break;
-      }
     }
     return false;
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -523,30 +523,30 @@ function toRegExpSource(
   let result = "";
   let backtrack = "";
   let prevCaptureType: 0 | 1 | 2 = 0;
-  let hasCapture = 0;
   let hasSegmentCapture = 0;
+  let hasWildcardAhead = false;
   let wildcardBacktrack = "";
   let index = 0;
 
-  function hasInSegment(index: number, type: Token["type"]) {
+  function seekWildcard(index: number, stopOnSegment = false) {
     while (index < tokens.length) {
       const token = tokens[index++];
-      if (token.type === type) return true;
-      if (token.type === "text") {
+      if (token.type === "wildcard") return true;
+      if (stopOnSegment && token.type === "text") {
         if (token.value.includes(delimiter)) break;
       }
     }
     return false;
   }
 
-  function peekText(index: number) {
+  function textRemaining(index: number) {
     let result = "";
     while (index < tokens.length) {
       const token = tokens[index++];
-      if (token.type !== "text") break;
+      if (token.type !== "text") return result;
+      if (token.value.includes(delimiter)) break;
       result += token.value;
     }
-    return result;
   }
 
   while (index < tokens.length) {
@@ -572,27 +572,35 @@ function toRegExpSource(
       keys.push(token);
 
       if (token.type === "param") {
-        result +=
-          hasSegmentCapture & 2 // Seen wildcard in segment.
-            ? `(${negate(delimiter, backtrack)}+)`
-            : hasInSegment(index, "wildcard") // See wildcard later in segment.
-              ? `(${negate(delimiter, peekText(index))}+)`
-              : hasSegmentCapture & 1 // Seen parameter in segment.
-                ? `(${negate(delimiter, backtrack)}+|${escape(backtrack)})`
-                : `(${negate(delimiter, "")}+)`;
+        if (hasSegmentCapture & 2) {
+          const value = negate(delimiter, backtrack);
+          result += `(${value}+?|${value}*${escape(backtrack)})`;
+        } else {
+          const text = textRemaining(index);
+
+          if (text) {
+            result += `(?=(${negate(delimiter, "")}+?)${escape(text)})\\${keys.length}`;
+          } else {
+            result += `(${negate(delimiter, "")}+)`;
+          }
+        }
 
         wildcardBacktrack += `\\${keys.length}`;
-        hasSegmentCapture = hasCapture |= prevCaptureType = 1;
+        hasSegmentCapture |= prevCaptureType = 1;
       } else {
-        result +=
-          hasSegmentCapture & 2 // Seen wildcard in segment.
-            ? `(${negate(backtrack, "")}+)`
-            : hasCapture & 2 // Seen wildcard before, block backtracking.
-              ? `((?:(?!${wildcardBacktrack})[^])+)`
-              : `([^]+)`;
+        // If we had a wildcard, close lookahead and reset.
+        if (hasWildcardAhead) result += `)${wildcardBacktrack}`;
 
-        wildcardBacktrack = "";
-        hasSegmentCapture = hasCapture |= prevCaptureType = 2;
+        hasWildcardAhead = seekWildcard(index);
+
+        // If another wildcard, open lookahead to prevent backtracking.
+        if (hasWildcardAhead) result += `(?=`;
+
+        // Greedy match for last wildcard only.
+        result += `([^]+${hasWildcardAhead ? "?" : ""})`;
+
+        wildcardBacktrack = `\\${keys.length}`; // Restart wildcard backtrack.
+        hasSegmentCapture |= prevCaptureType = 2;
       }
 
       backtrack = "";

--- a/src/index.ts
+++ b/src/index.ts
@@ -576,13 +576,13 @@ function toRegExpSource(
           const text = textRemaining(index);
 
           if (text) {
-            result += `(?=(${negate(delimiter, "")}+?)${escape(text)})\\${keys.length}`;
+            result += `(?=(${negate(delimiter, "")}+?)${escape(text)})(?:\\${keys.length})`;
           } else {
             result += `(${negate(delimiter, "")}+)`;
           }
         }
 
-        wildcardBacktrack += `\\${keys.length}`;
+        wildcardBacktrack += `(?:\\${keys.length})`;
         hasSegmentCapture |= prevCaptureType = 1;
       } else {
         // If we had a wildcard, close lookahead and reset.
@@ -596,7 +596,7 @@ function toRegExpSource(
         // Greedy match for last wildcard only.
         result += `([^]+${hasWildcardAhead ? "?" : ""})`;
 
-        wildcardBacktrack = `\\${keys.length}`; // Restart wildcard backtrack.
+        wildcardBacktrack = `(?:\\${keys.length})`; // Restart wildcard backtrack.
         hasSegmentCapture |= prevCaptureType = 2;
       }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -525,6 +525,7 @@ function toRegExpSource(
   let prevCaptureType: 0 | 1 | 2 = 0;
   let hasCapture = 0;
   let hasSegmentCapture = 0;
+  let wildcardBacktrack = "";
   let index = 0;
 
   function hasInSegment(index: number, type: Token["type"]) {
@@ -552,7 +553,9 @@ function toRegExpSource(
     const token = tokens[index++];
 
     if (token.type === "text") {
-      result += escape(token.value);
+      const value = escape(token.value);
+      result += value;
+      wildcardBacktrack += value;
       backtrack += token.value;
       if (token.value.includes(delimiter)) hasSegmentCapture = 0;
       continue;
@@ -566,6 +569,8 @@ function toRegExpSource(
         );
       }
 
+      keys.push(token);
+
       if (token.type === "param") {
         result +=
           hasSegmentCapture & 2 // Seen wildcard in segment.
@@ -576,19 +581,20 @@ function toRegExpSource(
                 ? `(${negate(delimiter, backtrack)}+|${escape(backtrack)})`
                 : `(${negate(delimiter, "")}+)`;
 
+        wildcardBacktrack += `\\${keys.length}`;
         hasSegmentCapture = hasCapture |= prevCaptureType = 1;
       } else {
         result +=
-          hasSegmentCapture & 2 || prevCaptureType === 2
+          hasSegmentCapture & 2 // Seen wildcard in segment.
             ? `(${negate(backtrack, "")}+)`
             : hasCapture & 2 // Seen wildcard before, block backtracking.
-              ? `((?:(?!\\${keys.length})[^])+)`
+              ? `((?:(?!${wildcardBacktrack})[^])+)`
               : `([^]+)`;
 
+        wildcardBacktrack = "";
         hasSegmentCapture = hasCapture |= prevCaptureType = 2;
       }
 
-      keys.push(token);
       backtrack = "";
       continue;
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -522,8 +522,8 @@ function toRegExpSource(
 ): string {
   let result = "";
   let backtrack = "";
-  let wildcardBacktrack = "";
   let prevCaptureType: 0 | 1 | 2 = 0;
+  let hasCapture = 0;
   let hasSegmentCapture = 0;
   let index = 0;
 
@@ -554,7 +554,6 @@ function toRegExpSource(
     if (token.type === "text") {
       result += escape(token.value);
       backtrack += token.value;
-      if (prevCaptureType === 2) wildcardBacktrack += token.value;
       if (token.value.includes(delimiter)) hasSegmentCapture = 0;
       continue;
     }
@@ -577,17 +576,16 @@ function toRegExpSource(
                 ? `(${negate(delimiter, backtrack)}+|${escape(backtrack)})`
                 : `(${negate(delimiter, "")}+)`;
 
-        hasSegmentCapture |= prevCaptureType = 1;
+        hasSegmentCapture = hasCapture |= prevCaptureType = 1;
       } else {
         result +=
-          hasSegmentCapture & 2 // Seen wildcard in segment.
+          hasSegmentCapture & 2 || prevCaptureType === 2
             ? `(${negate(backtrack, "")}+)`
-            : wildcardBacktrack // No capture in segment, seen wildcard in path.
-              ? `(${negate(wildcardBacktrack, "")}+|${negate(delimiter, "")}+)`
+            : hasCapture & 2 // Seen wildcard before, block backtracking.
+              ? `((?:(?!\\${keys.length})[^])+)`
               : `([^]+)`;
 
-        wildcardBacktrack = "";
-        hasSegmentCapture |= prevCaptureType = 2;
+        hasSegmentCapture = hasCapture |= prevCaptureType = 2;
       }
 
       keys.push(token);


### PR DESCRIPTION
After taking a look at https://github.com/pillarjs/path-to-regexp/pull/449 I thought I'd make another attempt at an idea I tried in the past to block backtracking, and it looks like it's working. Uses back references to reject the previous match (but only when the previous match was a param _and_ there's another wildcard).

Fixes the test case provided in that PR, and also the concerns I brought up in my comment.