### PR TITLE
Quote param names followed by astral ID_Continue text

### DIFF
--- a/src/cases.spec.ts
+++ b/src/cases.spec.ts
@@ -215,6 +215,32 @@ export const STRINGIFY_TESTS: StringifyTestSet[] = [
     expected: '/:"test"stuff',
   },
   {
+    // `\u{1D6FC}` is `ID_Continue`, so a bare name would absorb it on re-parse.
+    data: new TokenData([
+      { type: "text", value: "/" },
+      { type: "param", name: "test" },
+      { type: "text", value: "\u{1D6FC}" },
+    ]),
+    expected: '/:"test"\u{1D6FC}',
+  },
+  {
+    data: new TokenData([
+      { type: "text", value: "/" },
+      { type: "wildcard", name: "test" },
+      { type: "text", value: "\u{1D6FC}" },
+    ]),
+    expected: '/*"test"\u{1D6FC}',
+  },
+  {
+    // `\u{1F600}` is not `ID_Continue`, so the name stays unquoted.
+    data: new TokenData([
+      { type: "text", value: "/" },
+      { type: "param", name: "test" },
+      { type: "text", value: "\u{1F600}" },
+    ]),
+    expected: "/:test\u{1F600}",
+  },
+  {
     data: new TokenData([
       { type: "text", value: "\\" },
       { type: "param", name: "test" },

--- a/src/index.ts
+++ b/src/index.ts
@@ -676,8 +676,13 @@ function quoteName(name: string): string {
 function stringifyName(name: string, next: Token | undefined): string {
   if (!ID.test(name)) return quoteName(name);
 
-  if (next?.type === "text" && ID_CONTINUE.test(next.value[0])) {
-    return quoteName(name);
+  if (next?.type === "text") {
+    // Destructuring reads the first *code point*, matching `parse`, which
+    // iterates the path with `[...str]`. Indexing with `[0]` would read only the
+    // leading surrogate of an astral character, missing that the parser treats
+    // the whole character as `ID_Continue` and absorbs it into the name.
+    const [first = ""] = next.value;
+    if (ID_CONTINUE.test(first)) return quoteName(name);
   }
 
   return name;


### PR DESCRIPTION
`stringify` emits a bare parameter name when the text that follows starts with an astral character that is `ID_Continue`. The parser then reads that character back as part of the name.

```js
parse('/:"id"\u{1D6FC}').tokens;
// [{ type: 'text', value: '/' }, { type: 'param', name: 'id' }, { type: 'text', value: '\u{1D6FC}' }]

stringify(parse('/:"id"\u{1D6FC}'));
// actual:   '/:id\u{1D6FC}'   -> reparses to a single param named 'id\u{1D6FC}'
// expected: '/:"id"\u{1D6FC}' -> reparses to the tokens above
```

The docstring on `quoteName` states that names should "survive a `parse` -> `stringify` -> `parse` round trip". Running that property over 60,000 generated paths gave 33 violations, every one of them carrying an astral character. Regenerating the same inputs with astral characters removed gives 0 violations, both before and after this change.

The cause is at src/index.ts:679. `next.value[0]` reads the first UTF-16 code unit, which for an astral character is a lone surrogate and so fails `\p{ID_Continue}`. `parse` iterates with `[...str]` and sees the whole code point, so it treats the character as identifier continuation. Reading the first code point in `stringifyName` lines the two up.

Tests cover a param and a wildcard followed by U+1D6FC. A third case uses U+1F600, which is not `ID_Continue`, to pin that names not at risk stay unquoted.
