### PR TITLE
Release: 0.1.14

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,41 +1,46 @@
-0.1.13 / 2026-03-26
-==================
+0.1.14
+======
+
+  * Fix [CVE-2026-5099](https://www.cve.org/CVERecord?id=CVE-2026-5099) ([GHSA-m9m9-jm9g-cmp4](https://github.com/pillarjs/path-to-regexp/security/advisories/GHSA-m9m9-jm9g-cmp4))
+
+0.1.13
+======
 
   * Fix [CVE-2026-4867](https://www.cve.org/CVERecord?id=CVE-2026-4867) ([GHSA-37ch-88jc-xwx2](https://github.com/pillarjs/path-to-regexp/security/advisories/GHSA-37ch-88jc-xwx2))
 
-0.1.7 / 2015-07-28
-==================
+0.1.7
+=====
 
   * Fixed regression with escaped round brackets and matching groups.
 
-0.1.6 / 2015-06-19
-==================
+0.1.6
+=====
 
   * Replace `index` feature by outputting all parameters, unnamed and named.
 
-0.1.5 / 2015-05-08
-==================
+0.1.5
+=====
 
   * Add an index property for position in match result.
 
-0.1.4 / 2015-03-05
-==================
+0.1.4
+=====
 
   * Add license information
 
-0.1.3 / 2014-07-06
-==================
+0.1.3
+=====
 
   * Better array support
   * Improved support for trailing slash in non-ending mode
 
-0.1.0 / 2014-03-06
-==================
+0.1.0
+=====
 
   * add options.end
 
-0.0.2 / 2013-02-10
-==================
+0.0.2
+=====
 
   * Update to match current express
   * add .license property to component.json

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "path-to-regexp",
   "description": "Express style path to RegExp utility",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "files": [
     "index.js",
     "LICENSE"


### PR DESCRIPTION
### What's included in the `History.md`

```
0.1.14
======

  * Fix [CVE-2026-5099](https://www.cve.org/CVERecord?id=CVE-2026-5099) ([GHSA-m9m9-jm9g-cmp4](https://github.com/pillarjs/path-to-regexp/security/advisories/GHSA-m9m9-jm9g-cmp4))
```

## What's Changed

* Fix [CVE-2026-5099](https://www.cve.org/CVERecord?id=CVE-2026-5099) ([GHSA-m9m9-jm9g-cmp4](https://github.com/pillarjs/path-to-regexp/security/advisories/GHSA-m9m9-jm9g-cmp4))

**Full Changelog**: https://github.com/pillarjs/path-to-regexp/compare/v0.1.13...0.1.x